### PR TITLE
Fix stop condition

### DIFF
--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/overlays/eventconfig/EventConfigDialog.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/overlays/eventconfig/EventConfigDialog.kt
@@ -149,12 +149,12 @@ class EventConfigDialog(
 
             editStopAfter.apply {
                 setSelectAllOnFocus(true)
-                object : OnAfterTextChangedListener() {
+                addTextChangedListener(object : OnAfterTextChangedListener() {
                     override fun afterTextChanged(s: Editable?) {
                         val stopAfter = viewBinding.editStopAfter.text.toString()
                         viewModel?.setEventStopAfterExec(if (stopAfter.isNotEmpty()) stopAfter.toInt() else null)
                     }
-                }
+                })
             }
 
             listConditions.adapter = conditionsAdapter

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/overlays/eventconfig/EventConfigModel.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/overlays/eventconfig/EventConfigModel.kt
@@ -319,7 +319,7 @@ class EventConfigModel(context: Context) : OverlayViewModel(context) {
     fun setEventStopAfterExec(stopAfter: Int?) {
         configuredEvent.value?.let { event ->
             configuredEvent.value = event.copy(stopAfter = stopAfter)
-        } ?: throw IllegalStateException("Can't set event name, event is null!")
+        } ?: throw IllegalStateException("Can't set executions before scenario end, event is null!")
     }
 }
 


### PR DESCRIPTION
Hi. The stop condition number is not saved anymore in the EventConfigDialog. Apparently, the listener for changes of the edit field cannot be added with "object: ". I changed it according to the listener addition for the editName field.

fixes #78 