### PR TITLE
Added full_description.txt into their respective language directories 

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,11 +1,14 @@
-Klick'r est une application Android open-source conçue pour automatiser les tâches répétitives sans effort. Autrefois connue sous le nom de Smart AutoClicker, Klick'r offre des capacités uniques de détection d'images appliquées aux fonctionnalités traditionnelles d'auto-cliqueur, fournissant une solution polyvalente pour tous vos besoins d'automatisation.
+<p>Klick'r is an open-source Android application designed to automate repetitive tasks effortlessly. Formerly known as Smart AutoClicker, Klick'r offers unique image detection capabilities alongside traditional auto-clicking functionalities, providing a versatile solution for all your automation needs.
+</p>
+<p>Whether you’re a gamer automating in-game actions, a tester simulating user interactions, or anyone performing repetitive clicking tasks, Klick'r offers both image detection for sophisticated automation and a Regular Mode for straightforward auto-clicking.
+</p>
 
-Que vous soyez un joueur automatisant des actions en jeu, un testeur simulant des interactions utilisateur, ou toute personne effectuant des tâches de clic répétitives, Klick'r offre à la fois la détection d'images pour une automatisation sophistiquée et un mode régulier pour un auto-cliqueur simple.
+</br>
 
-Fonctionnalités Clés :
-Clics et Swipes : Automatisez les clics et les swipes avec précision en configurant les durées de pression, les durées de swipe et les positions. Déclenchez des actions sur les images détectées pour interagir sans effort avec des éléments dynamiques.
-Automatisation Avancée : Améliorez vos scripts d'automatisation avec des fonctionnalités avancées telles que les opérations sur les compteurs, les Intents Android et le contrôle de flux, vous offrant une flexibilité inégalée.
-Déclencheurs : Configurez des déclencheurs sophistiqués basés sur la détection d'images, les timers, les compteurs et les Broadcast Receiver Android pour adapter parfaitement vos tâches d'automatisation.
-Mode Régulier : Profitez d'une expérience de clic automatique simple avec notre mode régulier, conçu pour une configuration facile et idéal pour les tâches répétitives plus simples.
-Tutoriels : Apprenez à maîtriser Klick'r avec nos tutoriels de jeux interactifs, qui fournissent des instructions étape par étape pour vous aider à automatiser les tâches et à battre le jeu en utilisant les puissantes fonctionnalités de Klick'r.
-Open Source : En tant que projet open-source, Klick'r est continuellement amélioré par une communauté dévouée.
+## Key Features:
+* **Click and Swipes**: Automate clicks and swipes with precision by configuring press durations, swipe durations, and positions. Trigger actions on detected images to interact seamlessly with dynamic elements.
+* **Advanced Automation**: Enhance your automation scripts with advanced features like counters operations, Android Intents, and flow control, giving you unparalleled flexibility.
+* **Triggers**: Set up sophisticated triggers based on image detection, timers, counters, and Android broadcast receivers to perfectly tailor your automation tasks.
+* **Regular Mode**: Enjoy a straightforward auto-clicking experience with our Regular Mode, designed for easy configuration and ideal for simpler, repetitive tasks.
+* **Tutorials**: Learn to master Klick'r with our interactive game tutorials, which provide step-by-step instructions to help you automate tasks and beat the game using Klick'r's powerful features.
+* **Open Source**: As an open-source project, Klick'r is continuously improved by a dedicated community.

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -1,14 +1,14 @@
-<p>Klick'r is an open-source Android application designed to automate repetitive tasks effortlessly. Formerly known as Smart AutoClicker, Klick'r offers unique image detection capabilities alongside traditional auto-clicking functionalities, providing a versatile solution for all your automation needs.
+<p>Klick'r est une application Android open-source conçue pour automatiser les tâches répétitives sans effort. Autrefois connue sous le nom de Smart AutoClicker, Klick'r offre des capacités uniques de détection d'images appliquées aux fonctionnalités traditionnelles d'auto-cliqueur, fournissant une solution polyvalente pour tous vos besoins d'automatisation.
 </p>
-<p>Whether you’re a gamer automating in-game actions, a tester simulating user interactions, or anyone performing repetitive clicking tasks, Klick'r offers both image detection for sophisticated automation and a Regular Mode for straightforward auto-clicking.
+<p>Que vous soyez un joueur automatisant des actions en jeu, un testeur simulant des interactions utilisateur, ou toute personne effectuant des tâches de clic répétitives, Klick'r offre à la fois la détection d'images pour une automatisation sophistiquée et un mode régulier pour un auto-cliqueur simple.
 </p>
 
 </br>
 
-## Key Features:
-* **Click and Swipes**: Automate clicks and swipes with precision by configuring press durations, swipe durations, and positions. Trigger actions on detected images to interact seamlessly with dynamic elements.
-* **Advanced Automation**: Enhance your automation scripts with advanced features like counters operations, Android Intents, and flow control, giving you unparalleled flexibility.
-* **Triggers**: Set up sophisticated triggers based on image detection, timers, counters, and Android broadcast receivers to perfectly tailor your automation tasks.
-* **Regular Mode**: Enjoy a straightforward auto-clicking experience with our Regular Mode, designed for easy configuration and ideal for simpler, repetitive tasks.
-* **Tutorials**: Learn to master Klick'r with our interactive game tutorials, which provide step-by-step instructions to help you automate tasks and beat the game using Klick'r's powerful features.
-* **Open Source**: As an open-source project, Klick'r is continuously improved by a dedicated community.
+## Fonctionnalités Clés :
+* **Clics et Swipes** : Automatisez les clics et les swipes avec précision en configurant les durées de pression, les durées de swipe et les positions. Déclenchez des actions sur les images détectées pour interagir sans effort avec des éléments dynamiques.
+* **Automatisation Avancée** : Améliorez vos scripts d'automatisation avec des fonctionnalités avancées telles que les opérations sur les compteurs, les Intents Android et le contrôle de flux, vous offrant une flexibilité inégalée.
+* **Déclencheurs** : Configurez des déclencheurs sophistiqués basés sur la détection d'images, les timers, les compteurs et les Broadcast Receiver Android pour adapter parfaitement vos tâches d'automatisation.
+* **Mode Régulier** : Profitez d'une expérience de clic automatique simple avec notre mode régulier, conçu pour une configuration facile et idéal pour les tâches répétitives plus simples.
+* **Tutoriels** : Apprenez à maîtriser Klick'r avec nos tutoriels de jeux interactifs, qui fournissent des instructions étape par étape pour vous aider à automatiser les tâches et à battre le jeu en utilisant les puissantes fonctionnalités de Klick'r.
+* **Open Source** : En tant que projet open-source, Klick'r est continuellement amélioré par une communauté dévouée.


### PR DESCRIPTION
# Pull Request

## Error
`full_description.txt` in `en-US` was in written French and `full_description.txt` in `fr-FR` was written in English.

## Changes
These inaccuracies were fixed by adding the languages into their respective directory. 
Also added missing Markup styling for French description.