### PR TITLE
Remove some non-determinism

### DIFF
--- a/core/smart/detection/src/CMakeLists.txt
+++ b/core/smart/detection/src/CMakeLists.txt
@@ -16,6 +16,8 @@
 # Sets the minimum version of CMake required to build the native library.
 cmake_minimum_required(VERSION 3.22.1)
 
+add_link_options("LINKER:--build-id=none")
+
 # Declares and names the project.
 project("smartautoclicker")
 


### PR DESCRIPTION
Your app is not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro

Looking at the latest app report: https://verification.f-droid.org/packages/com.buzbuz.smartautoclicker/

We can remove the build id by adding this to the cmake file

and the timestamp diff block will be fixed on our side once https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1653 gets merged