### PR TITLE
Project maintenance

### DIFF
--- a/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/migrations/SQLiteTableDetails.kt
+++ b/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/migrations/SQLiteTableDetails.kt
@@ -90,7 +90,7 @@ internal class SQLiteTableDetails private constructor(
 
             val sqlCreateTempTable =
                 if (sqlCreateTable.isNullOrEmpty()) throw IllegalStateException("Can't drop column for $originTableName")
-                else sqlCreateTable!!.replace("CREATE TABLE `$originTableName`", "CREATE TABLE `$copyName`")
+                else sqlCreateTable.replace("CREATE TABLE `$originTableName`", "CREATE TABLE `$copyName`")
 
             return SQLiteTableDetails(sqlCreateTempTable, sqlCreateIndexes, copyName, sqlKeptColumns)
         }

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/implementation/MultiChoiceDialog.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/implementation/MultiChoiceDialog.kt
@@ -45,7 +45,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
  */
 open class MultiChoiceDialog<T : DialogChoice>(
     @StyleRes theme: Int,
-    @StringRes private val dialogTitleText: Int,
+    @field:StringRes private val dialogTitleText: Int,
     private val choices: List<T>,
     private val onChoiceSelected: (T) -> Unit,
     private val onCanceled: (() -> Unit)? = null,
@@ -215,9 +215,9 @@ private class SmallChoiceViewHolder<T : DialogChoice>(
 
 /** Base class for a dialog choice. */
 open class DialogChoice(
-    @StringRes val title: Int,
-    @StringRes val description: Int? = null,
-    @DrawableRes val iconId: Int? = null,
+    @field:StringRes val title: Int,
+    @field:StringRes val description: Int? = null,
+    @field:DrawableRes val iconId: Int? = null,
     val enabled: Boolean = true,
-    @DrawableRes val disabledIconId: Int? = null,
+    @field:DrawableRes val disabledIconId: Int? = null,
 )

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/brief/ItemsBriefMenu.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/brief/ItemsBriefMenu.kt
@@ -37,7 +37,7 @@ import com.buzbuz.smartautoclicker.core.ui.views.gesturerecord.toActionDescripti
 
 abstract class ItemBriefMenu(
     @StyleRes theme: Int? = null,
-    @StringRes private val noItemText: Int,
+    @field:StringRes private val noItemText: Int,
     private val initialItemIndex: Int = 0,
 ) : OverlayMenu(theme = theme, recreateOverlayViewOnRotation = true) {
 

--- a/core/common/permissions/src/main/java/com/buzbuz/smartautoclicker/core/common/permissions/ui/PermissionDialogViewModel.kt
+++ b/core/common/permissions/src/main/java/com/buzbuz/smartautoclicker/core/common/permissions/ui/PermissionDialogViewModel.kt
@@ -72,8 +72,8 @@ internal class PermissionDialogViewModel @Inject constructor(
 
 internal data class PermissionDialogUiState(
     val permission: Permission,
-    @StringRes val titleRes: Int,
-    @StringRes val descriptionRes: Int,
+    @field:StringRes val titleRes: Int,
+    @field:StringRes val descriptionRes: Int,
 )
 
 private fun Permission.toPermissionDialogUiState(): PermissionDialogUiState =

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/bindings/dropdown/DropdownItem.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/bindings/dropdown/DropdownItem.kt
@@ -9,9 +9,9 @@ import kotlin.time.Duration.Companion.seconds
 import com.buzbuz.smartautoclicker.core.ui.R
 
 open class DropdownItem(
-    @StringRes val title: Int,
-    @StringRes val helperText: Int? = null,
-    @DrawableRes val icon: Int? = null,
+    @field:StringRes val title: Int,
+    @field:StringRes val helperText: Int? = null,
+    @field:DrawableRes val icon: Int? = null,
 )
 
 sealed class TimeUnitDropDownItem(@StringRes title: Int) : DropdownItem(title) {

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/bindings/dropdown/IncludeDropdownWithSelectorExt.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/bindings/dropdown/IncludeDropdownWithSelectorExt.kt
@@ -112,5 +112,5 @@ data class SelectorState(
     val isClickable: Boolean,
     val title: String,
     val subText: String?,
-    @DrawableRes val iconRes: Int?,
+    @field:DrawableRes val iconRes: Int?,
 )

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/utils/AnimatedStatesImageButtonController.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/utils/AnimatedStatesImageButtonController.kt
@@ -26,10 +26,10 @@ import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
 /** Handles the states of an [ImageButton] and their animated transitions. */
 class AnimatedStatesImageButtonController(
     context: Context,
-    @DrawableRes private val state1StaticRes: Int,
-    @DrawableRes private val state2StaticRes: Int,
-    @DrawableRes state1to2AnimationRes: Int,
-    @DrawableRes state2to1AnimationRes: Int,
+    @field:DrawableRes private val state1StaticRes: Int,
+    @field:DrawableRes private val state2StaticRes: Int,
+    @field:DrawableRes state1to2AnimationRes: Int,
+    @field:DrawableRes state2to1AnimationRes: Int,
 ) {
 
     /** Animation from state 1 to state 2. */

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/utils/AutoHideAnimationController.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/utils/AutoHideAnimationController.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 
 class AutoHideAnimationController {
 
-    enum class ScreenSide(@AnimRes internal val inAnim: Int, @AnimRes internal val outAnim: Int) {
+    enum class ScreenSide(@field:AnimRes internal val inAnim: Int, @field:AnimRes internal val outAnim: Int) {
         LEFT(R.anim.slide_in_left, R.anim.slide_out_left),
         TOP(R.anim.slide_in_top, R.anim.slide_out_top),
         BOTTOM(R.anim.slide_in_bottom, R.anim.slide_out_bottom),

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/clickoffset/ClickOffsetStyle.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/clickoffset/ClickOffsetStyle.kt
@@ -23,9 +23,9 @@ import com.buzbuz.smartautoclicker.core.ui.R
 
 
 internal class ClickOffsetStyle(
-    @ColorInt val innerColor: Int,
-    @ColorInt val outerColor: Int,
-    @ColorInt val backgroundColor: Int,
+    @field:ColorInt val innerColor: Int,
+    @field:ColorInt val outerColor: Int,
+    @field:ColorInt val backgroundColor: Int,
     val radiusPx: Float,
     val innerRadiusPx: Float,
     val thicknessPx: Float,

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/gesturerecord/GestureRecordViewStyle.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/gesturerecord/GestureRecordViewStyle.kt
@@ -24,7 +24,7 @@ import com.buzbuz.smartautoclicker.core.ui.R
 
 
 internal class GestureRecorderViewStyle(
-    @ColorInt val color: Int,
+    @field:ColorInt val color: Int,
     val thicknessPx: Int,
     val lengthPx: Int,
 )

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/ClickBriefRenderer.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/ClickBriefRenderer.kt
@@ -127,7 +127,7 @@ data class ClickDescription(
 
 
 internal data class ClickBriefRendererStyle(
-    @ColorInt val backgroundColor: Int,
+    @field:ColorInt val backgroundColor: Int,
     val outerPaint: Paint,
     val innerPaint: Paint,
     val outerRadiusPx: Float,

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/DefaultBriefRenderer.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/DefaultBriefRenderer.kt
@@ -74,8 +74,8 @@ internal class DefaultBriefRenderer(
 }
 
 internal data class DefaultBriefRendererStyle(
-    @ColorInt val backgroundColor: Int,
-    @ColorInt val iconColor: Int,
+    @field:ColorInt val backgroundColor: Int,
+    @field:ColorInt val iconColor: Int,
     val iconSize: Float,
     val outerPaint: Paint,
 )

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/ImageConditionBriefRenderer.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/ImageConditionBriefRenderer.kt
@@ -193,8 +193,8 @@ enum class ImageConditionBriefRenderingType {
 }
 
 internal data class ImageConditionBriefRendererStyle(
-    @ColorInt val backgroundColor: Int,
-    @ColorInt val selectorColor: Int,
+    @field:ColorInt val backgroundColor: Int,
+    @field:ColorInt val selectorColor: Int,
     val thicknessPx: Int,
     val cornerRadiusPx: Float,
 )

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/PauseBriefRenderer.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/PauseBriefRenderer.kt
@@ -120,7 +120,7 @@ data class PauseDescription(
 ) : ItemBriefDescription
 
 internal data class PauseBriefRendererStyle(
-    @ColorInt val backgroundColor: Int,
+    @field:ColorInt val backgroundColor: Int,
     val outerPaint: Paint,
     val linePaint: Paint,
     val thicknessPx: Float,

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/SwipeBriefRenderer.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/itembrief/renderers/SwipeBriefRenderer.kt
@@ -176,7 +176,7 @@ data class SwipeDescription(
 ) : ItemBriefDescription
 
 internal data class SwipeBriefRendererStyle(
-    @ColorInt val backgroundColor: Int,
+    @field:ColorInt val backgroundColor: Int,
     val linePaint: Paint,
     val outerFromPaint: Paint,
     val outerToPaint: Paint,

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/DisplayBorderComponent.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/DisplayBorderComponent.kt
@@ -185,6 +185,6 @@ internal class DisplayBorderComponent (
  */
 internal class DisplayBorderComponentStyle(
     displayConfigManager: DisplayConfigManager,
-    @ColorInt val color: Int,
+    @field:ColorInt val color: Int,
     val thicknessPx: Int,
 ) : ViewStyle(displayConfigManager)

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/SelectorComponent.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/SelectorComponent.kt
@@ -353,8 +353,8 @@ internal class SelectorComponentStyle(
     val selectorAreaOffset: Int,
     val cornerRadius: Float,
     val selectorThickness: Float,
-    @ColorInt val selectorColor: Int,
-    @ColorInt val selectorBackgroundColor: Int,
+    @field:ColorInt val selectorColor: Int,
+    @field:ColorInt val selectorBackgroundColor: Int,
 ) : ViewStyle(displayConfigManager)
 
 /** The ratio of the maximum width to be considered as the minimum width. */

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/hints/Hints.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/hints/Hints.kt
@@ -103,7 +103,7 @@ internal open class SingleHint(
     iconsSize: Int,
     maxArea: Rect,
     @DrawableRes iconId: Int,
-    @Size(1) private val inSelector: BooleanArray,
+    @field:Size(1) private val inSelector: BooleanArray,
 ) : Hint(context, iconsSize, iconId, maxArea, inSelector) {
 
     override fun invalidate(selectorArea: Rect, newCenterX: Int, newCenterY: Int,
@@ -135,7 +135,7 @@ internal class DoubleHint(
     maxArea: Rect,
     private val iconsMargin: Int,
     @DrawableRes @Size(2) icons: IntArray,
-    @Size(2) private val inSelector: BooleanArray,
+    @field:Size(2) private val inSelector: BooleanArray,
     private val isVertical: Boolean,
 ): SingleHint(context, iconsSize, maxArea, icons[0], booleanArrayOf(inSelector[0])) {
 

--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/hints/HintsComponent.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/viewcomponents/hints/HintsComponent.kt
@@ -218,12 +218,12 @@ internal class HintsComponentStyle(
     displayConfigManager: DisplayConfigManager,
     val iconsMargin: Int,
     val iconsSize: Int,
-    @DrawableRes val moveIcon: Int,
-    @DrawableRes val upIcon: Int,
-    @DrawableRes val downIcon: Int,
-    @DrawableRes val leftIcon: Int,
-    @DrawableRes val rightIcon: Int,
-    @DrawableRes val pinchIcon: Int? = null,
+    @field:DrawableRes val moveIcon: Int,
+    @field:DrawableRes val upIcon: Int,
+    @field:DrawableRes val downIcon: Int,
+    @field:DrawableRes val leftIcon: Int,
+    @field:DrawableRes val rightIcon: Int,
+    @field:DrawableRes val pinchIcon: Int? = null,
     val pinchIconMargin: Int? = null,
 ) : ViewStyle(displayConfigManager)
 

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration10to11Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration10to11Tests.kt
@@ -16,10 +16,12 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.os.Build
 
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 
@@ -27,6 +29,7 @@ import com.buzbuz.smartautoclicker.core.database.ClickDatabase
 import com.buzbuz.smartautoclicker.core.database.entity.ClickPositionType
 import com.buzbuz.smartautoclicker.core.database.entity.EventToggleType
 import com.buzbuz.smartautoclicker.core.database.utils.*
+import org.junit.Before
 
 import org.junit.Rule
 import org.junit.Test
@@ -40,8 +43,6 @@ import org.robolectric.annotation.Config
 class Migration10to11Tests {
 
     private companion object {
-        private const val TEST_DB = "migration-test"
-
         private const val OLD_DB_VERSION = 10
         private const val NEW_DB_VERSION = 11
 
@@ -132,6 +133,15 @@ class Migration10to11Tests {
         )
     }
 
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
+
     @Test
     fun migrate_quality() {
         // Given
@@ -139,12 +149,12 @@ class Migration10to11Tests {
         val quality = 1200
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.execSQL(getInsertV10Scenario(id, quality))
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Scenarios()).use { cursor ->
 
                 // Verify
@@ -162,12 +172,12 @@ class Migration10to11Tests {
         val expectedSwipe = TEST_SWIPE
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Swipe(expectedSwipe)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -184,12 +194,12 @@ class Migration10to11Tests {
         val expectedPause = TEST_PAUSE
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Pause(expectedPause)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -206,12 +216,12 @@ class Migration10to11Tests {
         val expectedIntent = TEST_INTENT
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Intent(expectedIntent)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -228,12 +238,12 @@ class Migration10to11Tests {
         val expectedToggleEvent = TEST_TOGGLE_EVENT
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10ToggleEvent(expectedToggleEvent)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -250,12 +260,12 @@ class Migration10to11Tests {
         val v10Click = TEST_CLICK_ON_POSITION
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Click(v10Click)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -275,12 +285,12 @@ class Migration10to11Tests {
         val v10Click = TEST_CLICK_ON_CONDITION
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Click(v10Click)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -302,13 +312,13 @@ class Migration10to11Tests {
         val v10Click = TEST_CLICK_ON_CONDITION
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Click(v10Click)
             dbV10.insertTestCondition(conditionId, shouldBeDetected)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -330,13 +340,13 @@ class Migration10to11Tests {
         val v10Click = TEST_CLICK_ON_CONDITION
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Click(v10Click)
             dbV10.insertTestCondition(conditionId, shouldBeDetected)
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify
@@ -363,7 +373,7 @@ class Migration10to11Tests {
         val v10ClickOnCondition = TEST_CLICK_ON_CONDITION
 
         // Insert in V10 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).use { dbV10 ->
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { dbV10 ->
             dbV10.insertV10Click(v10ClickOnPosition)
             dbV10.insertV10Click(v10ClickOnCondition)
             dbV10.insertTestCondition(condition1Id, condition1ShouldBeDetected)
@@ -372,7 +382,7 @@ class Migration10to11Tests {
         }
 
         // Migrate
-        helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration10to11).use { dbV11 ->
             dbV11.query(getV11Actions()).use { cursor ->
 
                 // Verify

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration3to4Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration3to4Tests.kt
@@ -16,10 +16,12 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.database.Cursor
 import android.os.Build
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 
@@ -36,6 +38,7 @@ import com.buzbuz.smartautoclicker.core.database.utils.getV4Scenarios
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,14 +50,19 @@ import org.robolectric.annotation.Config
 @Config(sdk = [Build.VERSION_CODES.Q])
 class Migration3to4Tests {
 
-    private companion object {
-        private const val TEST_DB = "migration-test"
-    }
-
     @get:Rule val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         ClickDatabase::class.java,
     )
+
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
 
     @Test
     fun migrateScenarios_one() {
@@ -62,13 +70,13 @@ class Migration3to4Tests {
         val scenarioName = "TOTO"
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, scenarioName))
             close()
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val scenarioCursor = dbV4.query(getV4Scenarios())
@@ -90,7 +98,7 @@ class Migration3to4Tests {
         val scenarioName3 = "TUTU"
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId1, scenarioName1))
             execSQL(getInsertV3Scenario(scenarioId2, scenarioName2))
             execSQL(getInsertV3Scenario(scenarioId3, scenarioName3))
@@ -98,7 +106,7 @@ class Migration3to4Tests {
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val scenarioCursor = dbV4.query(getV4Scenarios())
@@ -128,7 +136,7 @@ class Migration3to4Tests {
         val threshold = 10
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, "TOTO"))
             execSQL(
                 getInsertV3Click(clickId, scenarioId, "TATA", 1, 1, 1, 1, 1,
@@ -140,7 +148,7 @@ class Migration3to4Tests {
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val conditionCursor = dbV4.query(getV4Conditions())
@@ -183,7 +191,7 @@ class Migration3to4Tests {
         val threshold2 = 2
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, "TOTO"))
             execSQL(
                 getInsertV3Click(clickId, scenarioId, "TATA", 1, 1, 1, 1, 1,
@@ -199,7 +207,7 @@ class Migration3to4Tests {
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val conditionCursor = dbV4.query(getV4Conditions())
@@ -241,14 +249,14 @@ class Migration3to4Tests {
         val priority = 1
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, "TOTO"))
             execSQL(getInsertV3Click(clickId, scenarioId, clickName, 1, 1, 1, 1, 1, conditionOperator, 1, stopAfter, priority))
             close()
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val eventCursor = dbV4.query(getV4Events())
@@ -283,7 +291,7 @@ class Migration3to4Tests {
         val priority2 = 2
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, "TOTO"))
             execSQL(
                 getInsertV3Click(clickId1, scenarioId, clickName1, 1, 1, 1, 1, 1,
@@ -297,7 +305,7 @@ class Migration3to4Tests {
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val eventCursor = dbV4.query(getV4Events())
@@ -337,7 +345,7 @@ class Migration3to4Tests {
         val clickDelayAfter = 500L
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, "TOTO"))
             execSQL(
                 getInsertV3Click(clickId, scenarioId, clickName, 1, clickX, clickY, 1, 1,
@@ -347,7 +355,7 @@ class Migration3to4Tests {
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val actionCursor = dbV4.query(getV4Actions())
@@ -389,7 +397,7 @@ class Migration3to4Tests {
         val swipeDelayAfter = 500L
 
         // Insert in V3 and close
-        helper.createDatabase(TEST_DB, 3).apply {
+        helper.createDatabase(dbPath, 3).apply {
             execSQL(getInsertV3Scenario(scenarioId, "TOTO"))
             execSQL(
                 getInsertV3Click(swipeId, scenarioId, swipeName, 2, swipeX1, swipeY1, swipeX2, swipeY2,
@@ -399,7 +407,7 @@ class Migration3to4Tests {
         }
 
         // Migrate
-        val dbV4 = helper.runMigrationsAndValidate(TEST_DB, 4, true, Migration3to4)
+        val dbV4 = helper.runMigrationsAndValidate(dbPath, 4, true, Migration3to4)
 
         // Verify
         val actionCursor = dbV4.query(getV4Actions())

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration4to5Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration4to5Tests.kt
@@ -16,18 +16,20 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.os.Build
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 
 import com.buzbuz.smartautoclicker.core.database.ClickDatabase
 import com.buzbuz.smartautoclicker.core.database.utils.getInsertV4Condition
 import com.buzbuz.smartautoclicker.core.database.utils.getV5Conditions
-import com.buzbuz.smartautoclicker.core.database.utils.*
 
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,26 +41,31 @@ import org.robolectric.annotation.Config
 @Config(sdk = [Build.VERSION_CODES.Q])
 class Migration4to5Tests {
 
-    private companion object {
-        private const val TEST_DB = "migration-test"
-    }
-
     @get:Rule
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         ClickDatabase::class.java,
     )
 
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
+
     @Test
     fun migrateConditions_nameColumn() {
         // Insert in V4 and close
-        helper.createDatabase(TEST_DB, 4).apply {
+        helper.createDatabase(dbPath, 4).apply {
             execSQL(getInsertV4Condition(24L, 1L, "", 0, 0, 0, 0, 0))
             close()
         }
 
         // Migrate
-        val dbV5 = helper.runMigrationsAndValidate(TEST_DB, 5, true, Migration4to5)
+        val dbV5 = helper.runMigrationsAndValidate(dbPath, 5, true, Migration4to5)
 
         // Verify
         val conditionsCursor = dbV5.query(getV5Conditions())
@@ -75,13 +82,13 @@ class Migration4to5Tests {
     @Test
     fun migrateConditions_detectionTypeColumn() {
         // Insert in V4 and close
-        helper.createDatabase(TEST_DB, 4).apply {
+        helper.createDatabase(dbPath, 4).apply {
             execSQL(getInsertV4Condition(24L, 1L, "", 0, 0, 0, 0, 0))
             close()
         }
 
         // Migrate
-        val dbV5 = helper.runMigrationsAndValidate(TEST_DB, 5, true, Migration4to5)
+        val dbV5 = helper.runMigrationsAndValidate(dbPath, 5, true, Migration4to5)
 
         // Verify
         val conditionsCursor = dbV5.query(getV5Conditions())
@@ -100,13 +107,13 @@ class Migration4to5Tests {
         val thresholdValue = 0
 
         // Insert in V4 and close
-        helper.createDatabase(TEST_DB, 4).apply {
+        helper.createDatabase(dbPath, 4).apply {
             execSQL(getInsertV4Condition(24L, 1L, "", 0, 0, 0, 0, thresholdValue))
             close()
         }
 
         // Migrate
-        val dbV5 = helper.runMigrationsAndValidate(TEST_DB, 5, true, Migration4to5)
+        val dbV5 = helper.runMigrationsAndValidate(dbPath, 5, true, Migration4to5)
 
         // Verify
         val conditionsCursor = dbV5.query(getV5Conditions())
@@ -129,13 +136,13 @@ class Migration4to5Tests {
         val thresholdValue =  Migration4to5.THRESHOLD_MAX_VALUE
 
         // Insert in V4 and close
-        helper.createDatabase(TEST_DB, 4).apply {
+        helper.createDatabase(dbPath, 4).apply {
             execSQL(getInsertV4Condition(24L, 1L, "", 0, 0, 0, 0, thresholdValue))
             close()
         }
 
         // Migrate
-        val dbV5 = helper.runMigrationsAndValidate(TEST_DB, 5, true, Migration4to5)
+        val dbV5 = helper.runMigrationsAndValidate(dbPath, 5, true, Migration4to5)
 
         // Verify
         val conditionsCursor = dbV5.query(getV5Conditions())

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration5to6Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration5to6Tests.kt
@@ -16,9 +16,11 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.os.Build
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 
@@ -30,9 +32,9 @@ import com.buzbuz.smartautoclicker.core.database.utils.getInsertV5Pause
 import com.buzbuz.smartautoclicker.core.database.utils.getInsertV5Swipe
 import com.buzbuz.smartautoclicker.core.database.utils.getV6Actions
 import com.buzbuz.smartautoclicker.core.database.utils.getV6Conditions
-import com.buzbuz.smartautoclicker.core.database.utils.*
 
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,26 +45,31 @@ import org.robolectric.annotation.Config
 @Config(sdk = [Build.VERSION_CODES.Q])
 class Migration5to6Tests {
 
-    private companion object {
-        private const val TEST_DB = "migration-test"
-    }
-
     @get:Rule
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
         ClickDatabase::class.java,
     )
 
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
+
     @Test
     fun migrateConditions_shouldBeDetectedColumn() {
         // Insert in V5 and close
-        helper.createDatabase(TEST_DB, 5).apply {
+        helper.createDatabase(dbPath, 5).apply {
             execSQL(getInsertV5Condition(24L, 1L, "", "", 0, 0, 0, 0, 0, 1))
             close()
         }
 
         // Migrate
-        val dbV6 = helper.runMigrationsAndValidate(TEST_DB, 6, true, Migration5to6)
+        val dbV6 = helper.runMigrationsAndValidate(dbPath, 6, true, Migration5to6)
 
         // Verify
         val conditionsCursor = dbV6.query(getV6Conditions())
@@ -83,13 +90,13 @@ class Migration5to6Tests {
     @Test
     fun migrateActions_clickOnConditionColumn_click() {
         // Insert in V5 and close
-        helper.createDatabase(TEST_DB, 5).apply {
+        helper.createDatabase(dbPath, 5).apply {
             execSQL(getInsertV5Click(24L, 1L, "", ActionType.CLICK.toString(), 0, 0, 0, 0))
             close()
         }
 
         // Migrate
-        val dbV6 = helper.runMigrationsAndValidate(TEST_DB, 6, true, Migration5to6)
+        val dbV6 = helper.runMigrationsAndValidate(dbPath, 6, true, Migration5to6)
 
         // Verify
         val actionCursor = dbV6.query(getV6Actions())
@@ -115,13 +122,13 @@ class Migration5to6Tests {
     @Test
     fun migrateActions_clickOnConditionColumn_swipe() {
         // Insert in V5 and close
-        helper.createDatabase(TEST_DB, 5).apply {
+        helper.createDatabase(dbPath, 5).apply {
             execSQL(getInsertV5Swipe(24L, 1L, "", ActionType.SWIPE.toString(), 0, 0, 0, 0, 0, 0))
             close()
         }
 
         // Migrate
-        val dbV6 = helper.runMigrationsAndValidate(TEST_DB, 6, true, Migration5to6)
+        val dbV6 = helper.runMigrationsAndValidate(dbPath, 6, true, Migration5to6)
 
         // Verify
         val actionCursor = dbV6.query(getV6Actions())
@@ -142,13 +149,13 @@ class Migration5to6Tests {
     @Test
     fun migrateActions_clickOnConditionColumn_pause() {
         // Insert in V5 and close
-        helper.createDatabase(TEST_DB, 5).apply {
+        helper.createDatabase(dbPath, 5).apply {
             execSQL(getInsertV5Pause(24L, 1L, "", ActionType.PAUSE.toString(), 0, 0))
             close()
         }
 
         // Migrate
-        val dbV6 = helper.runMigrationsAndValidate(TEST_DB, 6, true, Migration5to6)
+        val dbV6 = helper.runMigrationsAndValidate(dbPath, 6, true, Migration5to6)
 
         // Verify
         val actionCursor = dbV6.query(getV6Actions())

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration6to7Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration6to7Tests.kt
@@ -16,10 +16,12 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.database.Cursor
 import android.os.Build
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 
@@ -30,6 +32,7 @@ import com.buzbuz.smartautoclicker.core.database.utils.getV7EndCondition
 import com.buzbuz.smartautoclicker.core.database.utils.getV7Scenario
 
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,10 +42,6 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 class Migration6to7Tests {
-
-    private companion object {
-        private const val TEST_DB = "migration-test"
-    }
 
     @get:Rule
     val helper: MigrationTestHelper = MigrationTestHelper(
@@ -71,16 +70,25 @@ class Migration6to7Tests {
         )
     }
 
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
+
     @Test
     fun migrateScenario_detectionQuality() {
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(24L, "TOTO"))
             close()
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify
         val scenarioCursor = dbV7.query(getV7Scenario())
@@ -101,13 +109,13 @@ class Migration6to7Tests {
     @Test
     fun migrateScenario_endConditionOperator() {
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(24L, "TOTO"))
             close()
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify
         val scenarioCursor = dbV7.query(getV7Scenario())
@@ -128,13 +136,13 @@ class Migration6to7Tests {
     @Test
     fun migrateEndCondition_noEvents() {
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(24L, "TOTO"))
             close()
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify
         val endConditionCursor = dbV7.query(getV7EndCondition())
@@ -147,14 +155,14 @@ class Migration6to7Tests {
     @Test
     fun migrateEndCondition_events_NoStopAfter() {
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(24L, "TOTO"))
             execSQL(getInsertV6Event(1L,24L, "TUTU", 2, null, 1))
             close()
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify
         val endConditionCursor = dbV7.query(getV7EndCondition())
@@ -172,7 +180,7 @@ class Migration6to7Tests {
         val stopAfter = 3
 
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(scenarioId, "TOTO"))
             execSQL(getInsertV6Event(1L, scenarioId, "TUTU", 2, null, 1))
             execSQL(getInsertV6Event(eventId, scenarioId, "TATA", 2, stopAfter, 2))
@@ -180,7 +188,7 @@ class Migration6to7Tests {
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify created end condition
         val endConditionCursor = dbV7.query(getV7EndCondition())
@@ -204,7 +212,7 @@ class Migration6to7Tests {
         val stopAfter2 = 8
 
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(scenarioId1, "TOTO"))
             execSQL(getInsertV6Event(1L, scenarioId1, "TUTU", 2, null, 1))
             execSQL(getInsertV6Event(eventId1, scenarioId1, "TATA", 2, stopAfter1, 2))
@@ -213,7 +221,7 @@ class Migration6to7Tests {
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify created end condition
         val endConditionCursor = dbV7.query(getV7EndCondition())
@@ -242,7 +250,7 @@ class Migration6to7Tests {
         val stopAfter2 = 8
 
         // Insert in V6 and close
-        helper.createDatabase(TEST_DB, 6).apply {
+        helper.createDatabase(dbPath, 6).apply {
             execSQL(getInsertV6Scenario(scenarioId1, "TOTO"))
             execSQL(getInsertV6Event(1L, scenarioId1, "TUTU", 2, null, 1))
             execSQL(getInsertV6Event(eventId1, scenarioId1, "TATA", 2, stopAfter1, 2))
@@ -252,7 +260,7 @@ class Migration6to7Tests {
         }
 
         // Migrate
-        val dbV7 = helper.runMigrationsAndValidate(TEST_DB, 7, true, Migration6to7)
+        val dbV7 = helper.runMigrationsAndValidate(dbPath, 7, true, Migration6to7)
 
         // Verify created end condition
         val endConditionCursor = dbV7.query(getV7EndCondition())

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration8To9Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration8To9Tests.kt
@@ -16,9 +16,11 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.database.Cursor
 import android.os.Build
 import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.buzbuz.smartautoclicker.core.database.ClickDatabase
@@ -26,9 +28,9 @@ import com.buzbuz.smartautoclicker.core.database.utils.getInsertV8Event
 import com.buzbuz.smartautoclicker.core.database.utils.getInsertV8Scenario
 import com.buzbuz.smartautoclicker.core.database.utils.getV9Events
 import com.buzbuz.smartautoclicker.core.database.utils.getV9Scenario
-import com.buzbuz.smartautoclicker.core.database.utils.*
 import com.buzbuz.smartautoclicker.core.database.utils.TestsData
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,10 +40,6 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 class Migration8To9Tests {
-
-    private companion object {
-        private const val TEST_DB = "migration-test"
-    }
 
     @get:Rule
     val helper: MigrationTestHelper = MigrationTestHelper(
@@ -60,10 +58,19 @@ class Migration8To9Tests {
         Assert.assertEquals("Invalid event priority", priority, getInt(getColumnIndex("priority")))
     }
 
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
+
     @Test
     fun migrate_scenario_randomize() {
         // Insert in V8 and close
-        helper.createDatabase(TEST_DB, 8).apply {
+        helper.createDatabase(dbPath, 8).apply {
             execSQL(
                 getInsertV8Scenario(
                 TestsData.SCENARIO_ID,
@@ -76,7 +83,7 @@ class Migration8To9Tests {
         }
 
         // Migrate
-        val dbV9 = helper.runMigrationsAndValidate(TEST_DB, 9, true)
+        val dbV9 = helper.runMigrationsAndValidate(dbPath, 9, true)
 
         // Verify
         val scenarioCursor = dbV9.query(getV9Scenario())
@@ -99,7 +106,7 @@ class Migration8To9Tests {
         val priority = 9
 
         // Insert in V8 and close
-        helper.createDatabase(TEST_DB, 8).apply {
+        helper.createDatabase(dbPath, 8).apply {
             execSQL(
                 getInsertV8Scenario(
                 TestsData.SCENARIO_ID,
@@ -123,7 +130,7 @@ class Migration8To9Tests {
         }
 
         // Migrate
-        val dbV9 = helper.runMigrationsAndValidate(TEST_DB, 9, true)
+        val dbV9 = helper.runMigrationsAndValidate(dbPath, 9, true)
 
         // Verify
         val scenarioCursor = dbV9.query(getV9Events())
@@ -146,7 +153,7 @@ class Migration8To9Tests {
     @Test
     fun migrate_event_enabledOnStart() {
         // Insert in V8 and close
-        helper.createDatabase(TEST_DB, 8).apply {
+        helper.createDatabase(dbPath, 8).apply {
             execSQL(
                 getInsertV8Scenario(
                 TestsData.SCENARIO_ID,
@@ -170,7 +177,7 @@ class Migration8To9Tests {
         }
 
         // Migrate
-        val dbV9 = helper.runMigrationsAndValidate(TEST_DB, 9, true)
+        val dbV9 = helper.runMigrationsAndValidate(dbPath, 9, true)
 
         // Verify
         val scenarioCursor = dbV9.query(getV9Events())

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration9to10Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration9to10Tests.kt
@@ -16,9 +16,11 @@
  */
 package com.buzbuz.smartautoclicker.core.database.migrations
 
+import android.content.Context
 import android.os.Build
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 
@@ -30,7 +32,7 @@ import com.buzbuz.smartautoclicker.core.database.utils.getInsertV9Click
 import com.buzbuz.smartautoclicker.core.database.utils.getInsertV9EmptyAction
 import com.buzbuz.smartautoclicker.core.database.utils.getInsertV9Swipe
 import com.buzbuz.smartautoclicker.core.database.utils.getV10Actions
-import com.buzbuz.smartautoclicker.core.database.utils.*
+import org.junit.Before
 
 import org.junit.Rule
 import org.junit.Test
@@ -44,8 +46,6 @@ import org.robolectric.annotation.Config
 class Migration9to10Tests {
 
     private companion object {
-        private const val TEST_DB = "migration-test"
-
         private const val OLD_DB_VERSION = 9
         private const val NEW_DB_VERSION = 10
 
@@ -92,18 +92,27 @@ class Migration9to10Tests {
         ClickDatabase::class.java,
     )
 
+    private lateinit var dbPath: String
+
+    @Before
+    fun setUp() {
+        dbPath = ApplicationProvider
+            .getApplicationContext<Context>()
+            .getDatabasePath("migration-test").path
+    }
+
     @Test
     fun migrate_click_durationOverLimit() {
         val oldDuration = Migration9to10.NEW_GESTURE_DURATION_LIMIT_MS + 500
 
         // Insert in V9 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).apply {
+        helper.createDatabase(dbPath, OLD_DB_VERSION).apply {
             execSQL(getSqlCreateV9Click(24L, oldDuration))
             close()
         }
 
         // Migrate
-        val dbV10 = helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration9to10)
+        val dbV10 = helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration9to10)
 
         // Verify
         val actionsCursor = dbV10.query(getV10Actions())
@@ -121,13 +130,13 @@ class Migration9to10Tests {
         val oldDuration = Migration9to10.NEW_GESTURE_DURATION_LIMIT_MS - 500
 
         // Insert in V9 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).apply {
+        helper.createDatabase(dbPath, OLD_DB_VERSION).apply {
             execSQL(getSqlCreateV9Click(24L, oldDuration))
             close()
         }
 
         // Migrate
-        val dbV10 = helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration9to10)
+        val dbV10 = helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration9to10)
 
         // Verify
         val actionsCursor = dbV10.query(getV10Actions())
@@ -145,13 +154,13 @@ class Migration9to10Tests {
         val oldDuration = Migration9to10.NEW_GESTURE_DURATION_LIMIT_MS + 500
 
         // Insert in V9 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).apply {
+        helper.createDatabase(dbPath, OLD_DB_VERSION).apply {
             execSQL(getSqlCreateV9Swipe(24L, oldDuration))
             close()
         }
 
         // Migrate
-        val dbV10 = helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration9to10)
+        val dbV10 = helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration9to10)
 
         // Verify
         val actionsCursor = dbV10.query(getV10Actions())
@@ -169,13 +178,13 @@ class Migration9to10Tests {
         val oldDuration = Migration9to10.NEW_GESTURE_DURATION_LIMIT_MS - 500
 
         // Insert in V9 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).apply {
+        helper.createDatabase(dbPath, OLD_DB_VERSION).apply {
             execSQL(getSqlCreateV9Swipe(24L, oldDuration))
             close()
         }
 
         // Migrate
-        val dbV10 = helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration9to10)
+        val dbV10 = helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration9to10)
 
         // Verify
         val actionsCursor = dbV10.query(getV10Actions())
@@ -194,7 +203,7 @@ class Migration9to10Tests {
         val durationBelow = Migration9to10.NEW_GESTURE_DURATION_LIMIT_MS - 500
 
         // Insert in V9 and close
-        helper.createDatabase(TEST_DB, OLD_DB_VERSION).apply {
+        helper.createDatabase(dbPath, OLD_DB_VERSION).apply {
             execSQL(getSqlCreateV9Click(1L, durationOver))
             execSQL(getSqlCreateV9Click(2L, durationBelow))
             execSQL(getSqlCreateV9Swipe(3L, durationOver))
@@ -206,7 +215,7 @@ class Migration9to10Tests {
         }
 
         // Migrate
-        val dbV10 = helper.runMigrationsAndValidate(TEST_DB, NEW_DB_VERSION, true, Migration9to10)
+        val dbV10 = helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration9to10)
 
         // Verify
         val actionsCursor = dbV10.query(getV10Actions())

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/condition/ConditionMapper.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/condition/ConditionMapper.kt
@@ -97,7 +97,6 @@ internal fun ConditionEntity.toDomain(cleanIds: Boolean = false): Condition =
         ConditionType.ON_BROADCAST_RECEIVED -> toDomainBroadcastReceived(cleanIds)
         ConditionType.ON_COUNTER_REACHED -> toDomainCounterReached(cleanIds)
         ConditionType.ON_TIMER_REACHED -> toDomainTimerReached(cleanIds)
-        else -> throw IllegalArgumentException("Unsupported condition type for a TriggerCondition")
     }
 
 /** @return the condition for this entity. */

--- a/feature/backup/src/main/java/com/buzbuz/smartautoclicker/feature/backup/ui/BackupViewModel.kt
+++ b/feature/backup/src/main/java/com/buzbuz/smartautoclicker/feature/backup/ui/BackupViewModel.kt
@@ -244,8 +244,8 @@ data class BackupDialogUiState(
 
     val fileSelectionText: String? = null,
     val textStatusText: String? = null,
-    @DrawableRes val iconStatus: Int? = null,
-    @ColorInt val iconTint: Int? = null,
+    @field:DrawableRes val iconStatus: Int? = null,
+    @field:ColorInt val iconTint: Int? = null,
 )
 
 /** Zip mime type. */

--- a/feature/dumb-config/src/main/java/com/buzbuz/smartautoclicker/feature/dumb/config/ui/actions/copy/DumbActionCopyModel.kt
+++ b/feature/dumb-config/src/main/java/com/buzbuz/smartautoclicker/feature/dumb/config/ui/actions/copy/DumbActionCopyModel.kt
@@ -109,7 +109,7 @@ sealed class DumbActionCopyItem {
      * Header item, delimiting sections.
      * @param title the title for the header.
      */
-    data class HeaderItem(@StringRes val title: Int) : DumbActionCopyItem()
+    data class HeaderItem(@field:StringRes val title: Int) : DumbActionCopyItem()
 
     /**
      * Action item.

--- a/feature/dumb-config/src/main/java/com/buzbuz/smartautoclicker/feature/dumb/config/ui/actions/copy/DumbActionDetails.kt
+++ b/feature/dumb-config/src/main/java/com/buzbuz/smartautoclicker/feature/dumb/config/ui/actions/copy/DumbActionDetails.kt
@@ -33,7 +33,7 @@ import com.buzbuz.smartautoclicker.feature.dumb.config.R
  * @param action the action represented by this item.
  */
 data class DumbActionDetails (
-    @DrawableRes val icon: Int,
+    @field:DrawableRes val icon: Int,
     val name: String,
     val detailsText: String,
     val repeatCountText: String?,
@@ -51,7 +51,6 @@ fun DumbAction.toDumbActionDetails(
         is DumbAction.DumbClick -> toClickDetails(context, withPositions, inError)
         is DumbAction.DumbSwipe -> toSwipeDetails(context, withPositions, inError)
         is DumbAction.DumbPause -> toPauseDetails(context, withPositions, inError)
-        else -> throw IllegalArgumentException("Not yet supported")
     }
 
 private fun DumbAction.DumbClick.toClickDetails(context: Context, withPositions: Boolean, inError: Boolean): DumbActionDetails =

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/copy/ActionCopyModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/copy/ActionCopyModel.kt
@@ -105,7 +105,7 @@ class ActionCopyModel @Inject constructor(
          * Header item, delimiting sections.
          * @param title the title for the header.
          */
-        data class HeaderItem(@StringRes val title: Int) : ActionCopyItem()
+        data class HeaderItem(@field:StringRes val title: Int) : ActionCopyItem()
 
         /**
          * Action item.

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/intent/IntentDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/intent/IntentDialog.kt
@@ -111,7 +111,6 @@ class IntentDialog(
                 listener.onDeleteClicked()
                 super.back()
             }
-            else -> Unit
         }
     }
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/toggleevent/ToggleEventViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/toggleevent/ToggleEventViewModel.kt
@@ -172,7 +172,7 @@ data class EventToggleSelectorState(
     val enableCount: Int,
     val toggleCount: Int,
     val disableCount: Int,
-    @StringRes val emptyText: Int?,
+    @field:StringRes val emptyText: Int?,
 )
 
 internal const val BUTTON_ENABLE_EVENT = 0

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/condition/UiImageCondition.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/condition/UiImageCondition.kt
@@ -31,9 +31,9 @@ data class UiImageCondition(
     override val condition: ImageCondition,
     override val name: String,
     override val haveError: Boolean,
-    @DrawableRes val shouldBeVisibleIconRes: Int,
-    @StringRes val shouldBeVisibleTextRes: Int,
-    @DrawableRes val detectionTypeIconRes: Int,
+    @field:DrawableRes val shouldBeVisibleIconRes: Int,
+    @field:StringRes val shouldBeVisibleTextRes: Int,
+    @field:DrawableRes val detectionTypeIconRes: Int,
     val thresholdText: String,
 ) : UiCondition()
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/condition/UiTriggerCondition.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/condition/UiTriggerCondition.kt
@@ -29,7 +29,7 @@ data class UiTriggerCondition(
     override val condition: TriggerCondition,
     override val name: String,
     override val haveError: Boolean,
-    @DrawableRes val iconRes: Int,
+    @field:DrawableRes val iconRes: Int,
     val description: String,
 ) : UiCondition()
 
@@ -47,7 +47,6 @@ internal fun TriggerCondition.getIconRes(): Int =
         is TriggerCondition.OnBroadcastReceived -> R.drawable.ic_broadcast_received
         is TriggerCondition.OnCounterCountReached -> R.drawable.ic_counter_reached
         is TriggerCondition.OnTimerReached -> R.drawable.ic_timer_reached
-        else -> throw UnsupportedOperationException("Unsupported condition type")
     }
 
 private fun TriggerCondition.getTriggerConditionDescription(context: Context): String =
@@ -68,8 +67,6 @@ private fun TriggerCondition.getTriggerConditionDescription(context: Context): S
             R.string.item_timer_reached_details,
             formatDuration(durationMs),
         )
-
-        else -> throw UnsupportedOperationException("Scenario Start and End Conditions are not supported here")
     }
 
 private fun TriggerCondition.OnCounterCountReached.getComparisonOperationDisplayName(context: Context): String =

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/event/UiImageEvent.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/event/UiImageEvent.kt
@@ -27,8 +27,8 @@ data class UiImageEvent(
     val name: String,
     val conditionsCountText: String,
     val actionsCountText: String,
-    @StringRes val enabledOnStartTextRes: Int,
-    @DrawableRes val enabledOnStartIconRes: Int,
+    @field:StringRes val enabledOnStartTextRes: Int,
+    @field:DrawableRes val enabledOnStartIconRes: Int,
     val haveError: Boolean,
 ) : UiEvent()
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/event/UiTriggerEvent.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/event/UiTriggerEvent.kt
@@ -27,8 +27,8 @@ data class UiTriggerEvent(
     val name: String,
     val conditionsCountText: String,
     val actionsCountText: String,
-    @StringRes val enabledOnStartTextRes: Int,
-    @DrawableRes val enabledOnStartIconRes: Int,
+    @field:StringRes val enabledOnStartTextRes: Int,
+    @field:DrawableRes val enabledOnStartIconRes: Int,
     val haveError: Boolean,
 ) : UiEvent()
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/copy/ConditionCopyModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/copy/ConditionCopyModel.kt
@@ -132,8 +132,6 @@ class ConditionCopyModel @Inject constructor(
 
                         is TriggerCondition.OnTimerReached -> item.uiCondition.condition.name.hashCode() +
                                 item.uiCondition.condition.durationMs
-
-                        else -> 0
                     }
             }
         }
@@ -145,7 +143,7 @@ class ConditionCopyModel @Inject constructor(
          * Header item, delimiting sections.
          * @param title the title for the header.
          */
-        data class HeaderItem(@StringRes val title: Int) : ConditionCopyItem()
+        data class HeaderItem(@field:StringRes val title: Int) : ConditionCopyItem()
 
         sealed class ConditionItem : ConditionCopyItem() {
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/EventChildrenCardsAdapter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/EventChildrenCardsAdapter.kt
@@ -64,6 +64,6 @@ internal object CardIconResDiffUtilCallback: DiffUtil.ItemCallback<EventChildren
 }
 
 data class EventChildrenItem(
-    @DrawableRes val iconRes: Int,
+    @field:DrawableRes val iconRes: Int,
     val isInError: Boolean,
 )

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/FieldEventChildren.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/FieldEventChildren.kt
@@ -108,6 +108,6 @@ private fun RecyclerView.setEmptySpaceClickListener(listener: (() -> Unit)?) {
 }
 
 private data class FieldTitles(
-    @StringRes val titleRes: Int,
-    @StringRes val emptyTitleRes: Int,
+    @field:StringRes val titleRes: Int,
+    @field:StringRes val emptyTitleRes: Int,
 )

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/copy/EventCopyModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/copy/EventCopyModel.kt
@@ -128,7 +128,7 @@ class EventCopyModel @Inject constructor(
          * @param title the title for the header.
          */
         data class Header(
-            @StringRes val title: Int,
+            @field:StringRes val title: Int,
         ) : EventCopyItem()
 
         sealed class EventItem : EventCopyItem() {

--- a/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/data/TutorialDataModel.kt
+++ b/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/data/TutorialDataModel.kt
@@ -29,8 +29,8 @@ internal data class TutorialData(
 )
 
 internal data class TutorialInfo(
-    @StringRes val nameResId: Int,
-    @StringRes val descResId: Int,
+    @field:StringRes val nameResId: Int,
+    @field:StringRes val descResId: Int,
 )
 
 internal sealed class TutorialStepData {
@@ -43,7 +43,7 @@ internal sealed class TutorialStepData {
     ) : TutorialStepData()
 
     internal data class TutorialOverlay(
-        @StringRes val contentTextResId: Int,
+        @field:StringRes val contentTextResId: Int,
         val image: TutorialStepImage? = null,
         override val stepStartCondition: StepStartCondition,
         val stepEndCondition: StepEndCondition,
@@ -51,8 +51,8 @@ internal sealed class TutorialStepData {
 }
 
 internal data class TutorialStepImage(
-    @DrawableRes val imageResId: Int,
-    @StringRes val imageDescResId: Int,
+    @field:DrawableRes val imageResId: Int,
+    @field:StringRes val imageDescResId: Int,
 )
 
 internal sealed class StepStartCondition {

--- a/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/data/game/TutorialGameDataModel.kt
+++ b/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/data/game/TutorialGameDataModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 internal data class TutorialGameData(
-    @StringRes val instructionsResId: Int,
+    @field:StringRes val instructionsResId: Int,
     val gameRules: TutorialGameRules,
 ) : TutorialGameRules by gameRules
 

--- a/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/domain/model/Tutorial.kt
+++ b/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/domain/model/Tutorial.kt
@@ -21,8 +21,8 @@ import androidx.annotation.StringRes
 import com.buzbuz.smartautoclicker.feature.tutorial.data.TutorialInfo
 
 data class Tutorial(
-    @StringRes val nameResId: Int,
-    @StringRes val descResId: Int,
+    @field:StringRes val nameResId: Int,
+    @field:StringRes val descResId: Int,
     val isUnlocked: Boolean,
 )
 

--- a/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/domain/model/TutorialStep.kt
+++ b/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/domain/model/TutorialStep.kt
@@ -31,15 +31,15 @@ sealed class TutorialStep {
     ): TutorialStep()
 
     data class TutorialOverlay(
-        @StringRes val tutorialInstructionsResId: Int,
+        @field:StringRes val tutorialInstructionsResId: Int,
         val tutorialImage: TutorialImage? = null,
         val closeType: CloseType,
     ): TutorialStep()
 }
 
 data class TutorialImage(
-    @DrawableRes val tutorialImageResId: Int,
-    @StringRes val tutorialImageDescResId: Int,
+    @field:DrawableRes val tutorialImageResId: Int,
+    @field:StringRes val tutorialImageDescResId: Int,
 )
 
 sealed class CloseType {

--- a/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/domain/model/game/TutorialGame.kt
+++ b/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/domain/model/game/TutorialGame.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 
 data class TutorialGame(
-    @StringRes val instructionsResId: Int,
+    @field:StringRes val instructionsResId: Int,
     val highScore: Int,
     val state: Flow<TutorialGameState>,
     val targets: StateFlow<Map<TutorialGameTargetType, PointF>>,

--- a/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/ui/overlay/TutorialFullscreenViewModel.kt
+++ b/feature/tutorial/src/main/java/com/buzbuz/smartautoclicker/feature/tutorial/ui/overlay/TutorialFullscreenViewModel.kt
@@ -80,15 +80,15 @@ class TutorialOverlayViewModel @Inject constructor(
 }
 
 data class UiTutorialOverlayState(
-    @StringRes val instructionsResId: Int,
+    @field:StringRes val instructionsResId: Int,
     val image: UiTutorialImage? = null,
     val exitButton: TutorialExitButton? = null,
     val isDisplayedInTopHalf: Boolean = true,
 )
 
 data class UiTutorialImage(
-    @DrawableRes val imageResId: Int,
-    @StringRes val imageDescResId: Int,
+    @field:DrawableRes val imageResId: Int,
+    @field:StringRes val imageDescResId: Int,
 )
 
 sealed class TutorialExitButton {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,31 +20,32 @@ androidxAnnotation = "1.9.1"
 androidxAppCompat = "1.7.1"
 androidxCardView = "1.0.0"
 androidxConstraintLayout = "2.2.1"
-androidxCoreKtx = "1.16.0"
-androidxDatastore = "1.1.7"
-androidxFragmentKtx = "1.8.8"
-androidxLifecycle = "2.9.1"
+androidxCoreKtx = "1.17.0"
+androidxDatastore = "1.2.0"
+androidxFragmentKtx = "1.8.9"
+androidxLifecycle = "2.10.0"
 androidxLifecycleExtension = "2.2.0"
-androidxNavigation = "2.9.1"
+androidxNavigation = "2.9.6"
 androidxRecyclerView = "1.4.0"
-androidxRoom = "2.7.2"
-androidxSplashScreen = "1.0.1"
+androidxRoom = "2.8.4"
+androidxSplashScreen = "1.2.0"
 androidxVectorDrawable = "1.2.0"
 
 # Other
-airbnbLottie = "6.6.7"
-googleMaterial = "1.12.0"
+airbnbLottie = "6.7.1"
+googleMaterial = "1.13.0"
 kotlinSerializationJson = "1.9.0"
 openCv = "4.12.0"
 googleDaggerHilt = "2.57.2"
 googleProtobufRuntime = "4.33.2"
 
 # PlayStore only
-androidBillingClient = "8.0.0"
-googleFirebaseBom = "33.16.0"
+androidBillingClient = "8.3.0"
+googleFirebaseBom = "34.07.0"
 googleFirebaseCrashlytics = "19.4.4"
-googleUserMessaging = "3.2.0"
-googleGmsAds = "24.4.0"
+googleFirebaseCrashlyticsNdk = "20.0.3"
+googleUserMessaging = "4.0.0"
+googleGmsAds = "24.9.0"
 googlePlayReview = "2.0.2"
 
 # Tests only
@@ -119,7 +120,7 @@ android-billingClient = { group = "com.android.billingclient", name = "billing",
 android-billingClient-ktx = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "androidBillingClient" }
 google-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "googleFirebaseBom" }
 google-firebase-crashlytics-ktx = { group = "com.google.firebase", name = "firebase-crashlytics-ktx", version.ref = "googleFirebaseCrashlytics" }
-google-firebase-crashlytics-ndk = { group = "com.google.firebase", name = "firebase-crashlytics-ndk", version.ref = "googleFirebaseCrashlytics" }
+google-firebase-crashlytics-ndk = { group = "com.google.firebase", name = "firebase-crashlytics-ndk", version.ref = "googleFirebaseCrashlyticsNdk" }
 google-dagger-hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "googleDaggerHilt" }
 google-userMessaging = { group = "com.google.android.ump", name = "user-messaging-platform", version.ref = "googleUserMessaging" }
 google-gms-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "googleGmsAds" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 
 # Android SDK
-androidCompileSdk = "35"
+androidCompileSdk = "36"
 androidMinSdk = "24"
 androidNdk = "28.2.13676358"
 
 # Build script
-googleFirebaseCrashlyticsGradle = "3.0.4"
-googleProtobufGradlePlugin = "0.9.5"
-googleServices = "4.4.3"
-androidGradlePlugin = "8.11.1"
+googleFirebaseCrashlyticsGradle = "3.0.6"
+googleProtobufGradlePlugin = "0.9.6"
+googleServices = "4.4.4"
+androidGradlePlugin = "8.11.2"
 java = "21"
 kotlin = "2.2.0"
 kotlinxCoroutines = "1.10.2"
@@ -36,8 +36,8 @@ airbnbLottie = "6.6.7"
 googleMaterial = "1.12.0"
 kotlinSerializationJson = "1.9.0"
 openCv = "4.12.0"
-googleDaggerHilt = "2.56.2"
-googleProtobufRuntime = "3.25.0"
+googleDaggerHilt = "2.57.2"
+googleProtobufRuntime = "4.33.2"
 
 # PlayStore only
 androidBillingClient = "8.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,14 +50,14 @@ googlePlayReview = "2.0.2"
 
 # Tests only
 androidxArchCoreTesting = "2.2.0"
-androidxTestCore = "1.6.1"
-androidxTestExtJunit = "1.2.1"
+androidxTestCore = "1.7.0"
+androidxTestExtJunit = "1.3.0"
 junit = "4.13.2"
-mockitoCore = "5.18.0"
-mockitoKotlin = "5.4.0"
-mockk = "1.14.4"
-robolectric = "4.15.1"
-espressoCore = "3.6.1"
+mockitoCore = "5.21.0"
+mockitoKotlin = "6.1.0"
+mockk = "1.14.6"        # 1.14.7 requires min Android SDK to 26
+robolectric = "4.16"
+espressoCore = "3.7.0"
 
 
 [libraries]

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/model/ScenarioListUiState.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/model/ScenarioListUiState.kt
@@ -69,7 +69,7 @@ data class ScenarioListUiState(
         data class Item(
             val visible: Boolean,
             val enabled: Boolean = true,
-            @IntRange(from = 0, to = 255) val iconAlpha: Int = 255,
+            @field:IntRange(from = 0, to = 255) val iconAlpha: Int = 255,
         )
 
         data object Search : Menu()


### PR DESCRIPTION
This PR updates the Android SDK to the latest version (SDK 36).

It also updates the following dependencies:

* Crashlytics gradle plugin 3.0.4 -> 3.0.6
* Protobuf gradle plugin 0.9.5 -> 0.9.6
* GMS 4.4.3 -> 4.4.4
* AGP 8.11.1 -> 8.11.2
* Hilt -> 2.57.2
* Protobuf runtime 3.25.0 -> 4.33.2
* AndroidX Core 1.16.0 -> 1.17.0
* AndroidX DataStore 1.1.7 -> 1.2.0
* AndroidX Fragment Ktx 1.8.8 -> 1.8.9
* AndroidX Lifecycle 2.9.1 -> 2.10.0
* AndroidX Navigation 2.9.1 -> 2.9.6
* AndroidX Room 2.7.2 -> 2.8.4
* AndroidX SplashScreen 1.0.1 -> 1.2.0
* Lottie 6.6.7 - 6.7.1
* Material 1.12.0 -> 1.13.0
* Android Billing Client 8.0.0 -> 8.3.0
* Firebase BOM 33.16.0 -> 34.07.0
* Firebase Crashlytics Ndk 19.4.4 -> 20.0.3
* Google UMP 3.2.0 -> 4.0.0
* Google Ads 24.4.0 -> 24.9.0

Test dependencies have also been updated:
* AndroidX test core 1.6.1 -> 1.7.0
* AndroidX test ext jUnit 1.2.1 -> 1.3.0
* Espresso core 3.6.1 -> 3.7.0
* Mockito core 5.18.0 -> 5.21.0
* Mockito kotlin 5.4.0 -> 6.1.0
* Mockk 1.14.4 -> 1.14.6 (1.14.7 requires min android sdk 26)
* Robolectric 4.15.1 -> 4.16


Those changes have introduced a few new requirments that have been implemented:
* Update test database path for unit tests
* Update kotlin annotation notation 
* Fix redundant checks on when clause due to new kotlin features.
