### PR TITLE
Fix purchase copy prompt gating and copy scenario dialog title

### DIFF
--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/creation/ScenarioCreationViewModel.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/creation/ScenarioCreationViewModel.kt
@@ -73,7 +73,7 @@ class ScenarioCreationViewModel @Inject constructor(
                 smartItem = ScenarioTypeItem.Smart,
                 selectedItem = selectedType,
                 showPaidLimitationWarning =
-                    billingState == UserBillingState.PURCHASED && selectedType == ScenarioTypeSelection.SMART
+                    billingState == UserBillingState.AD_REQUESTED && selectedType == ScenarioTypeSelection.SMART
             )
         }
 

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/copy/ScenarioCopyDialog.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/copy/ScenarioCopyDialog.kt
@@ -108,7 +108,7 @@ class ScenarioCopyDialog : DialogFragment() {
         }
 
         val dialog = MaterialAlertDialogBuilder(requireContext())
-            .setTitle("Copy Scenario")
+            .setTitle(R.string.dialog_title_copy_scenario)
             .setView(viewBinding.root)
             .setCancelable(false)
             .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm() }


### PR DESCRIPTION
## Summary
- Gate the scenario copy purchase prompt using `UserBillingState.AD_REQUESTED` instead of `UserBillingState.PURCHASED`, so the flow matches the ad-supported copy path.
- Use `R.string.dialog_title_copy_scenario` for the copy scenario dialog title.

## Notes
Independent of layout/i18n changes; safe to merge first.
