### PR TITLE
Fix overlay dialog layout when soft keyboard opens (IME)

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/OverlayDialog.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/OverlayDialog.kt
@@ -20,6 +20,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 
@@ -105,7 +106,7 @@ abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, 
 
             window?.apply {
                 setType(OverlayManager.OVERLAY_WINDOW_TYPE)
-                setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
+                applySoftInputMode(this)
                 decorView.setOnTouchListener(hideSoftInputTouchListener)
             }
 
@@ -118,6 +119,13 @@ abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, 
         }
 
         onDialogCreated(dialog!!)
+    }
+
+    protected open fun applySoftInputMode(window: Window) {
+        window.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE or
+                WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN,
+        )
     }
 
     @CallSuper


### PR DESCRIPTION
## Summary

Fixes layout misalignment when the soft keyboard opens in **accessibility overlay** `BottomSheetDialog`s (e.g. text fields in floating configuration UI).

## Problem

The overlay dialog window used `SOFT_INPUT_STATE_ALWAYS_HIDDEN`, which blocks normal IME behavior and prevents the window from resizing with the keyboard. Users saw content shift or appear in the wrong place after the keyboard appeared.

## Fix

Restore `applySoftInputMode(Window)` with:

`SOFT_INPUT_ADJUST_RESIZE | SOFT_INPUT_STATE_HIDDEN`

This matches the previous working behavior: the dialog can resize when the IME is shown, while still starting with the keyboard hidden until focus requests it.
