### PR TITLE
Fix scenario copy cancellation

### DIFF
--- a/core/dumb/src/main/java/com/buzbuz/smartautoclicker/core/dumb/domain/DumbRepository.kt
+++ b/core/dumb/src/main/java/com/buzbuz/smartautoclicker/core/dumb/domain/DumbRepository.kt
@@ -16,20 +16,30 @@
  */
 package com.buzbuz.smartautoclicker.core.dumb.domain
 
+import com.buzbuz.smartautoclicker.core.base.di.Dispatcher
+import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.IO
 import com.buzbuz.smartautoclicker.core.base.identifier.Identifier
 import com.buzbuz.smartautoclicker.core.dumb.data.DumbScenarioDataSource
 import com.buzbuz.smartautoclicker.core.dumb.data.database.DumbScenarioWithActions
 import com.buzbuz.smartautoclicker.core.dumb.domain.model.DumbAction
 import com.buzbuz.smartautoclicker.core.dumb.domain.model.DumbScenario
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class DumbRepository @Inject constructor(
+    @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
     private val dumbScenarioDataSource: DumbScenarioDataSource,
 ) : IDumbRepository {
+
+    private val coroutineScopeIo: CoroutineScope =
+        CoroutineScope(SupervisorJob() + ioDispatcher)
 
     override val dumbScenarios: Flow<List<DumbScenario>> =
         dumbScenarioDataSource.getAllDumbScenarios
@@ -50,8 +60,12 @@ class DumbRepository @Inject constructor(
     override suspend fun addDumbScenarioCopy(scenario: DumbScenarioWithActions): Long? =
         dumbScenarioDataSource.addDumbScenarioCopy(scenario)
 
-    override suspend fun addDumbScenarioCopy(scenarioId: Long, copyName: String): Long? =
-        dumbScenarioDataSource.addDumbScenarioCopy(scenarioId, copyName)
+    override fun addDumbScenarioCopy(scenarioId: Long, copyName: String, onCopyCompleted: () -> Unit) {
+        coroutineScopeIo.launch {
+            dumbScenarioDataSource.addDumbScenarioCopy(scenarioId, copyName)
+            onCopyCompleted()
+        }
+    }
 
     override suspend fun updateDumbScenario(scenario: DumbScenario) {
         dumbScenarioDataSource.updateDumbScenario(scenario)

--- a/core/dumb/src/main/java/com/buzbuz/smartautoclicker/core/dumb/domain/IDumbRepository.kt
+++ b/core/dumb/src/main/java/com/buzbuz/smartautoclicker/core/dumb/domain/IDumbRepository.kt
@@ -37,7 +37,7 @@ interface IDumbRepository {
 
     suspend fun addDumbScenarioCopy(scenario: DumbScenarioWithActions): Long?
 
-    suspend fun addDumbScenarioCopy(scenarioId: Long, copyName: String): Long?
+    fun addDumbScenarioCopy(scenarioId: Long, copyName: String, onCopyCompleted: () -> Unit)
 
     suspend fun updateDumbScenario(scenario: DumbScenario)
 

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/IRepository.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/IRepository.kt
@@ -73,10 +73,9 @@ interface IRepository {
      *
      * @param scenarioId the identifier of scenario to copy.
      * @param copyName the name for the copy.
-     *
-     * @return the database id of the copy, or null if the copy has encountered an error.
+     * @param onCopyCompleted called when the copy operation is completed.
      */
-    suspend fun addScenarioCopy(scenarioId: Long, copyName: String): Long?
+    fun addScenarioCopy(scenarioId: Long, copyName: String, onCopyCompleted: () -> Unit)
 
     /**
      * Update a scenario.

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/Repository.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/Repository.kt
@@ -19,6 +19,8 @@ package com.buzbuz.smartautoclicker.core.domain
 import android.util.Log
 import com.buzbuz.smartautoclicker.core.base.FILE_EXTENSION_PNG
 
+import com.buzbuz.smartautoclicker.core.base.di.Dispatcher
+import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.IO
 import com.buzbuz.smartautoclicker.core.base.extensions.mapList
 import com.buzbuz.smartautoclicker.core.base.identifier.Identifier
 import com.buzbuz.smartautoclicker.core.bitmaps.BitmapRepository
@@ -36,10 +38,14 @@ import com.buzbuz.smartautoclicker.core.domain.model.event.toDomainTriggerEvent
 import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.core.domain.model.scenario.toDomain
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.math.max
 
@@ -49,9 +55,13 @@ import kotlin.math.max
  * the application data folder.
  */
 internal class Repository @Inject internal constructor(
+    @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
     private val dataSource: ScenarioDataSource,
     private val bitmapRepository: BitmapRepository,
 ): IRepository {
+
+    private val coroutineScopeIo: CoroutineScope =
+        CoroutineScope(SupervisorJob() + ioDispatcher)
 
     override val isTutorialModeEnabled: Flow<Boolean> =
         dataSource.isTutorialModeEnabled
@@ -118,10 +128,14 @@ internal class Repository @Inject internal constructor(
         return dataSource.addCompleteScenario(scenario, events, ::clearRemovedConditionsBitmaps)
     }
 
-    override suspend fun addScenarioCopy(scenarioId: Long, copyName: String): Long? {
-        val (scenario, events) = dataSource.getCompleteScenario(scenarioId)
-            ?.toDomain(cleanIds = true) ?: return null
-        return dataSource.addCompleteScenario(scenario.copy(name = copyName), events, ::clearRemovedConditionsBitmaps)
+    override fun addScenarioCopy(scenarioId: Long, copyName: String, onCopyCompleted: () -> Unit) {
+        coroutineScopeIo.launch {
+            val (scenario, events) = dataSource.getCompleteScenario(scenarioId)
+                ?.toDomain(cleanIds = true) ?: return@launch
+
+            dataSource.addCompleteScenario(scenario.copy(name = copyName), events, ::clearRemovedConditionsBitmaps)
+            onCopyCompleted()
+        }
     }
 
     override suspend fun updateScenario(scenario: Scenario, events: List<Event>): Boolean =

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/di/Hilt.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/di/Hilt.kt
@@ -16,6 +16,8 @@
  */
 package com.buzbuz.smartautoclicker.core.domain.di
 
+import com.buzbuz.smartautoclicker.core.base.di.Dispatcher
+import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.IO
 import com.buzbuz.smartautoclicker.core.bitmaps.BitmapRepository
 import com.buzbuz.smartautoclicker.core.domain.IRepository
 import com.buzbuz.smartautoclicker.core.domain.Repository
@@ -26,6 +28,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 
+import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
 
 @Module
@@ -35,7 +38,8 @@ object RepositoryHiltModule {
     @Provides
     @Singleton
     internal fun providesRepository(
+        @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
         dataSource: ScenarioDataSource,
         bitmapManager: BitmapRepository,
-    ): IRepository = Repository(dataSource, bitmapManager)
+    ): IRepository = Repository(ioDispatcher, dataSource, bitmapManager)
 }

--- a/core/smart/domain/src/test/java/com/buzbuz/smartautoclicker/core/domain/RepositoryTests.kt
+++ b/core/smart/domain/src/test/java/com/buzbuz/smartautoclicker/core/domain/RepositoryTests.kt
@@ -36,6 +36,7 @@ import com.buzbuz.smartautoclicker.core.domain.model.scenario.ScenarioTestsData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 
 import org.junit.Assert.assertEquals
@@ -88,7 +89,7 @@ class RepositoryTests {
         mockWhen(mockTutoDatabase.conditionDao()).thenReturn(mockTutoConditionDao)
 
         val dataSource = ScenarioDataSource(mockDatabase, mockTutoDatabase)
-        repository = Repository(dataSource, mockBitmapManager)
+        repository = Repository(UnconfinedTestDispatcher(), dataSource, mockBitmapManager)
         clearInvocations(mockScenarioDao, mockEventDao, mockConditionDao)
     }
 

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/copy/ScenarioCopyDialog.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/copy/ScenarioCopyDialog.kt
@@ -27,6 +27,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.appcompat.app.AlertDialog
 
 import com.buzbuz.smartautoclicker.R
 import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setError
@@ -111,7 +112,7 @@ class ScenarioCopyDialog : DialogFragment() {
             .setTitle("Copy Scenario")
             .setView(viewBinding.root)
             .setCancelable(false)
-            .setPositiveButton(android.R.string.ok) { _, _ -> onConfirm() }
+            .setPositiveButton(android.R.string.ok, null)
             .setNegativeButton(android.R.string.cancel, null)
             .create()
 
@@ -120,6 +121,10 @@ class ScenarioCopyDialog : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
+
+        (dialog as? AlertDialog)
+            ?.getButton(AlertDialog.BUTTON_POSITIVE)
+            ?.setOnClickListener { onConfirm() }
 
         viewBinding.fieldScenarioName.textField.requestFocus()
         dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/copy/ScenarioCopyViewModel.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/copy/ScenarioCopyViewModel.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 
 import com.buzbuz.smartautoclicker.core.base.di.Dispatcher
-import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.IO
 import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.Main
 import com.buzbuz.smartautoclicker.core.domain.IRepository
 import com.buzbuz.smartautoclicker.core.dumb.domain.DumbRepository
@@ -31,13 +30,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 class ScenarioCopyViewModel @Inject constructor(
     @param:Dispatcher(Main) private val mainDispatcher: CoroutineDispatcher,
-    @param:Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
     private val smartRepository: IRepository,
     private val dumbRepository: DumbRepository,
 ) : ViewModel() {
@@ -54,13 +51,13 @@ class ScenarioCopyViewModel @Inject constructor(
         val name = copyName.value
         if (name.isNullOrEmpty()) return
 
-        viewModelScope.launch(ioDispatcher) {
-            if (isSmart) smartRepository.addScenarioCopy(scenarioId, name)
-            else dumbRepository.addDumbScenarioCopy(scenarioId, name)
-
-            withContext(mainDispatcher) {
+        val onCopyCompleted = {
+            viewModelScope.launch(mainDispatcher) {
                 onCompleted()
             }
         }
+
+        if (isSmart) smartRepository.addScenarioCopy(scenarioId, name, onCopyCompleted)
+        else dumbRepository.addDumbScenarioCopy(scenarioId, name, onCopyCompleted)
     }
 }


### PR DESCRIPTION
## Summary
- keep the copy scenario dialog open while validating the new scenario name
- start the copy only after validation succeeds
- run the copy work in a non-cancellable context so dismissing the dialog does not cancel the repository copy mid-flight

## Why
The dialog previously used the default `setPositiveButton` behavior, so pressing OK dismissed the dialog immediately. Since the copy coroutine is owned by the dialog view model, that could cancel the copy work before it completed.

## Validation
- `:smartautoclicker:compileFDroidDebugKotlin`
