### PR TITLE
Add overlay scenario switcher

### DIFF
--- a/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/ServiceNotificationController.kt
+++ b/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/ServiceNotificationController.kt
@@ -94,6 +94,15 @@ class ServiceNotificationController(
         )
     }
 
+    fun updateScenarioName(context: Context, scenarioName: String) {
+        val state = notificationState ?: return
+
+        updateNotificationState(
+            context,
+            state.copy(scenarioName = scenarioName)
+        )
+    }
+
     private fun updateNotification(context: Context, isNightModeEnabled: Boolean) {
         val state = notificationState ?: return
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/di/Hilt.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/di/Hilt.kt
@@ -54,6 +54,7 @@ import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.ScenarioDial
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.config.ScenarioConfigViewModel
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.imageevents.ImageEventListViewModel
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.more.MoreViewModel
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.switcher.ScenarioSwitchViewModel
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.triggerevents.TriggerEventListViewModel
 
 import dagger.hilt.EntryPoint
@@ -93,6 +94,7 @@ interface ScenarioConfigViewModelsEntryPoint {
     fun pauseViewModel(): PauseViewModel
     fun scenarioConfigViewModel(): ScenarioConfigViewModel
     fun scenarioDialogViewModel(): ScenarioDialogViewModel
+    fun scenarioSwitchViewModel(): ScenarioSwitchViewModel
     fun setTextViewModel(): SetTextViewModel
     fun systemActionViewModel(): SystemActionViewModel
     fun smartActionsBriefViewModel(): SmartActionsBriefViewModel

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
@@ -32,6 +32,7 @@ import com.buzbuz.smartautoclicker.core.base.isStopScenarioKey
 import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
 import com.buzbuz.smartautoclicker.core.common.overlays.manager.OverlayManager.Companion.showAsOverlay
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.OverlayMenu
+import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.core.ui.utils.AnimatedStatesImageButtonController
 import com.buzbuz.smartautoclicker.core.ui.utils.getDynamicColorsContext
 import com.buzbuz.smartautoclicker.feature.smart.config.R
@@ -42,6 +43,7 @@ import com.buzbuz.smartautoclicker.feature.smart.config.ui.mainmenu.debugging.Li
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.mainmenu.debugging.LiveDebuggingUiState
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.mainmenu.debugging.LiveDebuggingViewModel
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.ScenarioDialog
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.switcher.ScenarioSwitchDialog
 import com.buzbuz.smartautoclicker.feature.tutorial.ui.dialogs.createStopWithVolumeDownTutorialDialog
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -59,7 +61,10 @@ import kotlinx.coroutines.launch
  * There is no overlay views attached to this overlay menu, meaning that the user will always be able to clicks on the
  * Activities displayed below it.
  */
-class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
+class MainMenu(
+    private val onStopClicked: () -> Unit,
+    private val onSwitchScenarioSelected: (Scenario) -> Boolean,
+) : OverlayMenu() {
 
     /** The view model for this menu. */
     private val viewModel: MainMenuModel by viewModels(
@@ -125,6 +130,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch { viewModel.isStartButtonEnabled.collect(::updatePlayPauseButtonEnabledState) }
                 launch { viewModel.isMediaProjectionStarted.collect(::updateProjectionErrorBadge) }
+                launch { viewModel.isSwitchButtonVisible.collect(::updateSwitchButtonVisibility) }
                 launch { viewModel.detectionState.collect(::updateDetectionState) }
                 launch { viewModel.nativeLibError.collect(::showNativeLibErrorDialogIfNeeded) }
                 launch { debuggingViewModel.isDebugging.collect(::updateDebugOverlayViewVisibility) }
@@ -180,12 +186,18 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
         when (viewId) {
             R.id.btn_play -> onPlayPauseClicked()
             R.id.btn_click_list -> onConfigureClicked()
+            R.id.btn_switch_scenario -> onSwitchScenarioClicked()
             R.id.btn_stop -> onStopClicked()
         }
     }
 
     override fun getWindowMaximumSize(backgroundView: ViewGroup): Size {
+        val switchButtonVisibility = viewBinding.btnSwitchScenario.visibility
+
+        viewBinding.btnSwitchScenario.visibility = View.VISIBLE
         val bgSize = super.getWindowMaximumSize(backgroundView)
+        viewBinding.btnSwitchScenario.visibility = switchButtonVisibility
+
         return Size(
             bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_panel_width),
             bgSize.height,
@@ -242,6 +254,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
                     animateLayoutChanges {
                         setMenuItemVisibility(viewBinding.btnStop, true)
                         setMenuItemVisibility(viewBinding.btnClickList, true)
+                        setMenuItemVisibility(viewBinding.btnSwitchScenario, viewModel.isSwitchButtonVisible.value)
                         playPauseButtonController.toState1(true)
                     }
                 }
@@ -254,11 +267,21 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
                     animateLayoutChanges {
                         setMenuItemVisibility(viewBinding.btnStop, false)
                         setMenuItemVisibility(viewBinding.btnClickList, false)
+                        setMenuItemVisibility(viewBinding.btnSwitchScenario, false)
                         playPauseButtonController.toState2(true)
                     }
                 }
             }
         }
+    }
+
+    private fun updateSwitchButtonVisibility(isVisible: Boolean) {
+        if (viewBinding.btnPlay.tag == null) {
+            viewBinding.btnSwitchScenario.visibility = if (isVisible) View.VISIBLE else View.GONE
+            return
+        }
+
+        setMenuItemVisibility(viewBinding.btnSwitchScenario, isVisible)
     }
 
     private fun updateVisibilityForPaywall(isHidden: Boolean) {
@@ -335,6 +358,14 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             ),
             hideCurrent = true,
         )
+
+    private fun onSwitchScenarioClicked() {
+        overlayManager.navigateTo(
+            context = context,
+            newOverlay = ScenarioSwitchDialog(onSwitchScenarioSelected),
+            hideCurrent = true,
+        )
+    }
 
     private fun showScenarioSaveErrorDialog() {
         MaterialAlertDialogBuilder(context.getDynamicColorsContext(R.style.AppTheme))

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenuModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenuModel.kt
@@ -22,6 +22,8 @@ import android.view.View
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.buzbuz.smartautoclicker.core.domain.IRepository
+import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingRepository
 
 import com.buzbuz.smartautoclicker.core.processing.domain.model.DetectionState
@@ -52,6 +54,7 @@ import javax.inject.Inject
 /** View model for the [MainMenu]. */
 class MainMenuModel @Inject constructor(
     private val smartProcessingRepository: SmartProcessingRepository,
+    smartRepository: IRepository,
     private val editionRepository: EditionRepository,
     private val tutorialRepository: TutorialRepository,
     private val revenueRepository: IRevenueRepository,
@@ -86,6 +89,20 @@ class MainMenuModel @Inject constructor(
     val isMediaProjectionStarted: StateFlow<Boolean> = smartProcessingRepository.detectionState
         .map { it == DetectionState.RECORDING || it == DetectionState.DETECTING }
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    val switchableScenarios: StateFlow<List<Scenario>> = combine(
+        smartRepository.scenarios,
+        scenarioDbId,
+    ) { scenarios, currentScenarioId ->
+        scenarios.filter { scenario -> scenario.id.databaseId != currentScenarioId }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    val isSwitchButtonVisible: StateFlow<Boolean> = combine(
+        detectionState,
+        isMediaProjectionStarted,
+    ) { state, isProjectionStarted ->
+        state == UiState.Idle && isProjectionStarted
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     /** Tells if the scenario can be started. Edited scenario must be synchronized and engine should allow it. */
     val isStartButtonEnabled: Flow<Boolean> = combine(

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/switcher/ScenarioSwitchDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/switcher/ScenarioSwitchDialog.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.switcher
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.OverlayDialog
+import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
+import com.buzbuz.smartautoclicker.core.ui.bindings.lists.setEmptyText
+import com.buzbuz.smartautoclicker.core.ui.bindings.lists.updateState
+import com.buzbuz.smartautoclicker.feature.smart.config.R
+import com.buzbuz.smartautoclicker.feature.smart.config.databinding.DialogBaseSelectionBinding
+import com.buzbuz.smartautoclicker.feature.smart.config.databinding.ItemCounterNameBinding
+import com.buzbuz.smartautoclicker.feature.smart.config.di.ScenarioConfigViewModelsEntryPoint
+
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+import kotlinx.coroutines.launch
+
+class ScenarioSwitchDialog(
+    private val onScenarioSelected: (Scenario) -> Boolean,
+) : OverlayDialog(R.style.ScenarioConfigTheme) {
+
+    private val viewModel: ScenarioSwitchViewModel by viewModels(
+        entryPoint = ScenarioConfigViewModelsEntryPoint::class.java,
+        creator = { scenarioSwitchViewModel() },
+    )
+
+    private lateinit var viewBinding: DialogBaseSelectionBinding
+
+    private val scenarioAdapter = ScenarioSwitchAdapter { scenario ->
+        debounceUserInteraction {
+            if (onScenarioSelected(scenario)) back()
+        }
+    }
+
+    override fun onCreateView(): ViewGroup {
+        viewBinding = DialogBaseSelectionBinding.inflate(LayoutInflater.from(context)).apply {
+            layoutTopBar.apply {
+                dialogTitle.setText(R.string.dialog_title_switch_scenario)
+                buttonDismiss.setDebouncedOnClickListener { back() }
+            }
+
+            layoutLoadableList.apply {
+                setEmptyText(R.string.message_empty_scenario_switch_list_title)
+                list.adapter = scenarioAdapter
+                list.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+            }
+        }
+
+        return viewBinding.root
+    }
+
+    override fun onDialogCreated(dialog: BottomSheetDialog) {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.switchableScenarios.collect(::updateScenarios) }
+            }
+        }
+    }
+
+    private fun updateScenarios(scenarios: List<Scenario>) {
+        viewBinding.layoutLoadableList.updateState(scenarios)
+        scenarioAdapter.submitList(scenarios)
+    }
+}
+
+private class ScenarioSwitchAdapter(
+    private val onScenarioSelected: (Scenario) -> Unit,
+) : ListAdapter<Scenario, ScenarioSwitchViewHolder>(ScenarioDiffUtilCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ScenarioSwitchViewHolder =
+        ScenarioSwitchViewHolder(
+            viewBinding = ItemCounterNameBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            onScenarioSelected = onScenarioSelected,
+        )
+
+    override fun onBindViewHolder(holder: ScenarioSwitchViewHolder, position: Int) {
+        holder.onBind(getItem(position))
+    }
+}
+
+private object ScenarioDiffUtilCallback: DiffUtil.ItemCallback<Scenario>() {
+    override fun areItemsTheSame(oldItem: Scenario, newItem: Scenario): Boolean =
+        oldItem.id == newItem.id
+
+    override fun areContentsTheSame(oldItem: Scenario, newItem: Scenario): Boolean =
+        oldItem == newItem
+}
+
+private class ScenarioSwitchViewHolder(
+    private val viewBinding: ItemCounterNameBinding,
+    private val onScenarioSelected: (Scenario) -> Unit,
+) : RecyclerView.ViewHolder(viewBinding.root) {
+
+    fun onBind(scenario: Scenario) {
+        viewBinding.textCounterName.text = scenario.name
+        viewBinding.root.setOnClickListener { onScenarioSelected(scenario) }
+    }
+}

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/switcher/ScenarioSwitchViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/switcher/ScenarioSwitchViewModel.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.feature.smart.config.ui.scenario.switcher
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.buzbuz.smartautoclicker.core.domain.IRepository
+import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
+import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+import javax.inject.Inject
+
+class ScenarioSwitchViewModel @Inject constructor(
+    smartRepository: IRepository,
+    smartProcessingRepository: SmartProcessingRepository,
+) : ViewModel() {
+
+    private val currentScenarioId: StateFlow<Long?> = smartProcessingRepository.scenarioId
+        .map { it?.databaseId }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val switchableScenarios: StateFlow<List<Scenario>> = combine(
+        smartRepository.scenarios,
+        currentScenarioId,
+    ) { scenarios, currentId ->
+        scenarios.filter { scenario -> scenario.id.databaseId != currentId }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+}

--- a/feature/smart-config/src/main/res/drawable/ic_switch_scenario.xml
+++ b/feature/smart-config/src/main/res/drawable/ic_switch_scenario.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@color/overlayMenuButtons"
+        android:pathData="M7,7h11l-4,-4l1.4,-1.4L21.8,8l-6.4,6.4L14,13l4,-4H7V7zM17,17H6l4,4l-1.4,1.4L2.2,16l6.4,-6.4L10,11l-4,4h11v2z" />
+</vector>

--- a/feature/smart-config/src/main/res/layout/overlay_menu.xml
+++ b/feature/smart-config/src/main/res/layout/overlay_menu.xml
@@ -76,6 +76,13 @@
                     android:contentDescription="@string/content_desc_open_event_list" />
 
                 <ImageButton
+                    android:id="@+id/btn_switch_scenario"
+                    style="@style/AppTheme.Overlay.FloatingMenu.Buttons"
+                    android:src="@drawable/ic_switch_scenario"
+                    android:visibility="gone"
+                    android:contentDescription="@string/content_desc_switch_scenario" />
+
+                <ImageButton
                     android:id="@+id/btn_move"
                     style="@style/AppTheme.Overlay.FloatingMenu.Buttons"
                     android:src="@drawable/ic_move"

--- a/feature/smart-config/src/main/res/values/strings.xml
+++ b/feature/smart-config/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
     <!-- Dialog Scenario =========================================================================================== -->
 
     <string name="dialog_title_scenario_config">Scenario</string>
+    <string name="dialog_title_switch_scenario">Switch scenario</string>
 
     <string name="message_empty_screen_event_title">No screen events !</string>
     <string name="message_empty_screen_event_desc">A screen event contains a set of actions executed when a specific condition is detected on the screen.\nYou need at least one screen or trigger event in your scenario to execute it.</string>
@@ -163,6 +164,7 @@
     <string name="message_empty_trigger_condition_list_desc">A condition is a custom criteria for starting an action.</string>
     <string name="message_empty_action_list_title">No actions !</string>
     <string name="message_empty_action_list_desc">An action is an interaction (click, swipe…) with your phone triggered when the created conditions are fulfilled.</string>
+    <string name="message_empty_scenario_switch_list_title">No other Smart scenarios</string>
 
     <string name="menu_item_title_conditions">Conditions</string>
     <string name="menu_item_title_actions">Actions</string>
@@ -419,6 +421,7 @@
     <string name="content_desc_actions_count">The number of actions in this event</string>
     <string name="content_desc_image_condition">The image to be detected</string>
     <string name="content_desc_open_event_list">Open the event list</string>
+    <string name="content_desc_switch_scenario">Switch scenario</string>
     <string name="content_desc_application_icon">The icon of the application to start.</string>
 
 </resources>

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/SmartAutoClickerService.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/SmartAutoClickerService.kt
@@ -121,6 +121,7 @@ class SmartAutoClickerService : AccessibilityService() {
                 settingsRepository = settingsRepository,
                 debuggingRepository = debuggingRepository,
                 onStart = ::onLocalServiceStarted,
+                onScenarioChanged = tileRepository::setTileScenario,
                 onStop = ::onLocalServiceStopped,
             )
         )

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/localservice/ILocalService.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/localservice/ILocalService.kt
@@ -23,6 +23,7 @@ import com.buzbuz.smartautoclicker.core.dumb.domain.model.DumbScenario
 interface ILocalService {
     fun startDumbScenario(dumbScenario: DumbScenario)
     fun startSmartScenario(resultCode: Int, data: Intent, scenario: Scenario)
+    fun switchSmartScenario(scenario: Scenario): Boolean
     fun stop()
     fun release()
 }

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/localservice/LocalService.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/localservice/LocalService.kt
@@ -59,6 +59,7 @@ class LocalService(
     private val revenueRepository: IRevenueRepository,
     private val debuggingRepository: DebuggingRepository,
     private val onStart: (scenarioId: Long, isSmart: Boolean, foregroundNotification: Notification?) -> Unit,
+    private val onScenarioChanged: (scenarioId: Long, isSmart: Boolean) -> Unit,
     private val onStop: () -> Unit,
 ) : ILocalService {
 
@@ -154,7 +155,10 @@ class LocalService(
         )
 
         startJob = serviceScope.launch {
-            val mainMenu = MainMenu { stop() }
+            val mainMenu = MainMenu(
+                onStopClicked = { stop() },
+                onSwitchScenarioSelected = ::switchSmartScenario,
+            )
 
             smartProcessingRepository.apply {
                 setScenarioId(scenario.id, markAsUsed = true)
@@ -171,6 +175,25 @@ class LocalService(
                 data = data,
             )
         }
+    }
+
+    override fun switchSmartScenario(scenario: Scenario): Boolean {
+        if (!state.isStarted || !state.isSmartLoaded) return false
+
+        serviceScope.launch {
+            startJob?.join()
+
+            val wasRunning = smartProcessingRepository.isRunning()
+            if (wasRunning) smartProcessingRepository.stopDetection()
+
+            smartProcessingRepository.setScenarioId(scenario.id, markAsUsed = true)
+            notificationController.updateScenarioName(context, scenario.name)
+            onScenarioChanged(scenario.id.databaseId, true)
+
+            if (wasRunning) startSmartScenario()
+        }
+
+        return true
     }
 
     override fun stop() {


### PR DESCRIPTION
## Summary
- add a Switch button to the Smart floating menu while detection is idle and media projection is active
- show an overlay scenario picker listing other Smart scenarios without leaving the app being automated
- switch the loaded Smart scenario without stopping the active screen recording session
- update the service notification title and quick settings tile after switching

## Why
This reduces the friction described in #848. If a user is already inside another app/game with a Smart scenario loaded and paused, switching scenarios currently requires leaving that app, opening Klick'r, selecting another scenario, and granting screen recording permission again.

This PR keeps the switch flow inside the accessibility overlay. The intended flow is:
1. Pause the current Smart scenario from the overlay.
2. Tap Switch.
3. Pick another Smart scenario from the overlay picker.
4. Press Play and continue in the same foreground app.

This is related to #493, but it is intentionally narrower: it is manual, user-driven switching from the floating overlay, not an automation action that chains scenarios.

## Notes
- This is scoped to Smart scenarios only.
- The picker excludes the currently loaded scenario.
- Seamless switching requires the existing media projection session to still be active; the Switch button is hidden if media projection is no longer available.
- If detection happened to be running during a service-level switch, the service stops detection, switches the scenario id, and restarts detection.

## Validation
- `:smartautoclicker:compileFDroidDebugKotlin`

Closes #848.
Related to #493.
