### PR TITLE
Fix overlay edge position restore

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuPositionDataSource.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuPositionDataSource.kt
@@ -74,13 +74,13 @@ class OverlayMenuPositionDataSource @Inject constructor(
 
         lastLoadedOrientation = orientation
         lastLoadedPosition = when (orientation) {
-            Configuration.ORIENTATION_LANDSCAPE -> Point(
-                sharedPreferences.getInt(PREFERENCE_MENU_X_LANDSCAPE_KEY, 0),
-                sharedPreferences.getInt(PREFERENCE_MENU_Y_LANDSCAPE_KEY, 0),
+            Configuration.ORIENTATION_LANDSCAPE -> loadPosition(
+                xKey = PREFERENCE_MENU_X_LANDSCAPE_KEY,
+                yKey = PREFERENCE_MENU_Y_LANDSCAPE_KEY,
             )
-            Configuration.ORIENTATION_PORTRAIT -> Point(
-                sharedPreferences.getInt(PREFERENCE_MENU_X_PORTRAIT_KEY, 0),
-                sharedPreferences.getInt(PREFERENCE_MENU_Y_PORTRAIT_KEY, 0),
+            Configuration.ORIENTATION_PORTRAIT -> loadPosition(
+                xKey = PREFERENCE_MENU_X_PORTRAIT_KEY,
+                yKey = PREFERENCE_MENU_Y_PORTRAIT_KEY,
             )
             else -> return null
         }
@@ -140,6 +140,15 @@ class OverlayMenuPositionDataSource @Inject constructor(
 
     fun isPositionLocked(): Boolean =
         lockedMenuPosition != null
+
+    private fun loadPosition(xKey: String, yKey: String): Point? {
+        if (!sharedPreferences.contains(xKey) || !sharedPreferences.contains(yKey)) return null
+
+        return Point(
+            sharedPreferences.getInt(xKey, 0),
+            sharedPreferences.getInt(yKey, 0),
+        )
+    }
 
     override fun dump(writer: PrintWriter, prefix: CharSequence) {
         writer.append(prefix)

--- a/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuPositionDataSourceTests.kt
+++ b/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuPositionDataSourceTests.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/** Test the [OverlayMenuPositionDataSource] class. */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class OverlayMenuPositionDataSourceTests {
+
+    private lateinit var context: Context
+    private lateinit var dataSource: OverlayMenuPositionDataSource
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences(OverlayMenuPositionDataSource.PREFERENCE_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+
+        dataSource = OverlayMenuPositionDataSource(context)
+    }
+
+    @Test
+    fun loadLandscapePosition_withZeroX_returnsSavedPosition() {
+        mockSavedLandscapePosition(x = 0, y = 42)
+
+        val position = dataSource.loadMenuPosition(Configuration.ORIENTATION_LANDSCAPE)
+
+        assertEquals(0, position?.x)
+        assertEquals(42, position?.y)
+    }
+
+    @Test
+    fun loadLandscapePosition_withZeroY_returnsSavedPosition() {
+        mockSavedLandscapePosition(x = 84, y = 0)
+
+        val position = dataSource.loadMenuPosition(Configuration.ORIENTATION_LANDSCAPE)
+
+        assertEquals(84, position?.x)
+        assertEquals(0, position?.y)
+    }
+
+    @Test
+    fun loadLandscapePosition_withZeroXAndY_returnsSavedPosition() {
+        mockSavedLandscapePosition(x = 0, y = 0)
+
+        val position = dataSource.loadMenuPosition(Configuration.ORIENTATION_LANDSCAPE)
+
+        assertEquals(0, position?.x)
+        assertEquals(0, position?.y)
+    }
+
+    @Test
+    fun loadLandscapePosition_withMissingKeys_returnsNull() {
+        assertNull(dataSource.loadMenuPosition(Configuration.ORIENTATION_LANDSCAPE))
+    }
+
+    private fun mockSavedLandscapePosition(x: Int, y: Int) {
+        context.getSharedPreferences(OverlayMenuPositionDataSource.PREFERENCE_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(OverlayMenuPositionDataSource.PREFERENCE_MENU_X_LANDSCAPE_KEY, x)
+            .putInt(OverlayMenuPositionDataSource.PREFERENCE_MENU_Y_LANDSCAPE_KEY, y)
+            .commit()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #851.

This PR fixes overlay menu position restore for valid edge coordinates. A saved position with `x = 0`, `y = 0`, or both should mean "the user placed the overlay on the screen edge", not "there is no saved position".

## Root Cause

`SharedPreferences.getInt(..., 0)` used `0` both as the missing-value fallback and as a valid coordinate. The restore code then treated `0` as invalid, so edge placements could fall back to first-run centering.

## Changes

- Use `SharedPreferences.contains(...)` to distinguish missing keys from saved zero coordinates.
- Preserve first-run centering when no saved position exists.
- Add unit coverage for saved `(0, y)`, `(x, 0)`, `(0, 0)`, and missing preferences.

## Validation

- `./gradlew.bat --no-daemon --max-workers=3 --console=plain :core:common:overlays:testFDroidDebugUnitTest`
