### PR TITLE
Place overlay debug panels on the side that fits

### DIFF
--- a/core/common/overlays/build.gradle.kts
+++ b/core/common/overlays/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
     implementation(libs.androidx.appCompat)
+    implementation(libs.androidx.constraintLayout)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
 

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
@@ -47,6 +47,8 @@ import com.buzbuz.smartautoclicker.core.common.overlays.base.BaseOverlay
 import com.buzbuz.smartautoclicker.core.common.overlays.di.OverlaysEntryPoint
 import com.buzbuz.smartautoclicker.core.common.overlays.manager.OverlayManager
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.OverlayMenuAnimations
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelController
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelSide
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.OverlayMenuMoveTouchEventHandler
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.OverlayMenuPositionDataSource
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.OverlayMenuResizeController
@@ -101,6 +103,8 @@ abstract class OverlayMenu(
     /** The layout parameters of the menu layout. */
     private val menuLayoutParams: WindowManager.LayoutParams =
         WindowManager.LayoutParams().apply { copyFrom(baseLayoutParams) }
+    /** The logical position of the menu button cluster, saved independently from side panels. */
+    private val menuAnchorPosition: Point = Point(0, 0)
 
     private val animations: OverlayMenuAnimations = OverlayMenuAnimations()
 
@@ -201,7 +205,10 @@ abstract class OverlayMenu(
         setupButtons(buttonsContainer)
 
         // Setup the touch event handler for the move button
-        moveTouchEventHandler = OverlayMenuMoveTouchEventHandler(::updateMenuPosition)
+        moveTouchEventHandler = OverlayMenuMoveTouchEventHandler(
+            onMenuMoved = ::updateMenuPosition,
+            getCurrentMenuPosition = { Point(menuAnchorPosition) },
+        )
 
         // Restore the last menu position, if any.
         menuLayoutParams.gravity = Gravity.TOP or Gravity.START
@@ -431,6 +438,31 @@ abstract class OverlayMenu(
     }
 
     /**
+     * Get the width of the logical menu anchor. By default, the whole window is the anchor.
+     * Menus with adaptive side panels can override this with the button cluster width.
+     */
+    protected open fun getMenuAnchorWidth(windowSize: Size): Int = windowSize.width
+
+    /**
+     * Called before applying the menu window position. Implementations can shift the window while preserving
+     * [anchorPosition] as the user-controlled position, for example when placing a panel on the left of the buttons.
+     */
+    protected open fun onMenuAnchorPositionUpdated(anchorPosition: Point, windowSize: Size): Point = anchorPosition
+
+    protected fun chooseHorizontalSidePanelSide(
+        anchorPosition: Point,
+        anchorWidth: Int,
+        panelWidth: Int,
+        sidePanelController: HorizontalSidePanelController,
+    ): HorizontalSidePanelSide =
+        sidePanelController.chooseSide(
+            anchorX = anchorPosition.x,
+            anchorWidth = anchorWidth,
+            screenWidth = displayConfigManager.displayConfig.sizePx.x,
+            panelWidth = panelWidth,
+        )
+
+    /**
      * Change the menu view visibility.
      * @param visibility the new visibility to apply.
      */
@@ -476,6 +508,10 @@ abstract class OverlayMenu(
         resizeController.animateLayoutChanges(layoutChanges)
     }
 
+    protected fun refreshMenuLayout() {
+        forceWindowResize()
+    }
+
     private fun forceWindowResize() {
         Log.d(TAG, "Force window resize")
         onNewWindowSize(resizeController.measureMenuSize())
@@ -484,6 +520,7 @@ abstract class OverlayMenu(
     private fun onNewWindowSize(size: Size) {
         menuLayoutParams.width = size.width
         menuLayoutParams.height = size.height
+        updateMenuPosition(menuAnchorPosition)
 
         if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
             Log.d(TAG, "Updating menu window size: ${size.width}/${size.height}")
@@ -544,10 +581,17 @@ abstract class OverlayMenu(
     /** Safe setter for the position of the overlay menu ensuring it will not be displayed outside the screen. */
     private fun updateMenuPosition(position: Point) {
         val displaySize = displayConfigManager.displayConfig.sizePx
-        if (displaySize.x < menuLayout.width || displaySize.y < menuLayout.height) return
+        val windowSize = getMenuWindowSize()
+        if (displaySize.x < windowSize.width || displaySize.y < windowSize.height) return
 
-        menuLayoutParams.x = position.x.coerceIn(0, displaySize.x - menuLayout.width)
-        menuLayoutParams.y = position.y.coerceIn(0, displaySize.y - menuLayout.height)
+        val anchorWidth = getMenuAnchorWidth(windowSize)
+        menuAnchorPosition.x = position.x.coerceIn(0, displaySize.x - anchorWidth)
+        menuAnchorPosition.y = position.y.coerceIn(0, displaySize.y - windowSize.height)
+
+        val windowPosition = onMenuAnchorPositionUpdated(Point(menuAnchorPosition), windowSize)
+
+        menuLayoutParams.x = windowPosition.x.coerceIn(0, displaySize.x - windowSize.width)
+        menuLayoutParams.y = windowPosition.y.coerceIn(0, displaySize.y - windowSize.height)
 
         if (lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
             Log.d(TAG, "Updating menu window position: ${menuLayoutParams.x}/${menuLayoutParams.y}")
@@ -557,14 +601,14 @@ abstract class OverlayMenu(
 
     private fun loadMenuPosition(orientation: Int) {
         val savedPosition = positionDataSource.loadMenuPosition(orientation)
-        if (savedPosition != null && savedPosition.x != 0 && savedPosition.y != 0) {
+        if (savedPosition != null) {
             updateMenuPosition(savedPosition)
         } else {
             menuLayout.doWhenMeasured {
                 updateMenuPosition(
                     Point(
-                        (displayConfigManager.displayConfig.sizePx.x - menuLayout.width) / 2,
-                        (displayConfigManager.displayConfig.sizePx.y / 2) - menuLayout.height,
+                        (displayConfigManager.displayConfig.sizePx.x - getMenuAnchorWidth(getMenuWindowSize())) / 2,
+                        (displayConfigManager.displayConfig.sizePx.y / 2) - getMenuWindowSize().height,
                     )
                 )
             }
@@ -573,10 +617,16 @@ abstract class OverlayMenu(
 
     private fun saveMenuPosition(orientation: Int) {
         positionDataSource.saveMenuPosition(
-            position = Point(menuLayoutParams.x, menuLayoutParams.y),
+            position = Point(menuAnchorPosition),
             orientation = orientation,
         )
     }
+
+    private fun getMenuWindowSize(): Size =
+        Size(
+            if (menuLayoutParams.width > 0) menuLayoutParams.width else menuLayout.width,
+            if (menuLayoutParams.height > 0) menuLayoutParams.height else menuLayout.height,
+        )
 
     private fun onLockedPositionChanged(lockedPosition: Point?) {
         if (lockedPosition != null) {

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
@@ -140,6 +140,8 @@ abstract class OverlayMenu(
     private var hideOverlayButton: ImageButton? = null
     /** The move button, if provided. */
     private var moveButton: View? = null
+    /** True while the user is dragging this overlay menu. */
+    private var moveInProgress: Boolean = false
 
     /**
      * The view to be displayed between the current activity and the overlay menu.
@@ -208,6 +210,8 @@ abstract class OverlayMenu(
         moveTouchEventHandler = OverlayMenuMoveTouchEventHandler(
             onMenuMoved = ::updateMenuPosition,
             getCurrentMenuPosition = { Point(menuAnchorPosition) },
+            onMoveStarted = { moveInProgress = true },
+            onMoveFinished = ::onMenuMoveFinished,
         )
 
         // Restore the last menu position, if any.
@@ -462,6 +466,9 @@ abstract class OverlayMenu(
             panelWidth = panelWidth,
         )
 
+    protected fun shouldRefreshSidePanelPlacement(): Boolean =
+        !moveInProgress
+
     /**
      * Change the menu view visibility.
      * @param visibility the new visibility to apply.
@@ -575,6 +582,11 @@ abstract class OverlayMenu(
         if (resizeController.isAnimating) return false
 
         return moveTouchEventHandler.onTouchEvent(menuLayout, event)
+    }
+
+    private fun onMenuMoveFinished() {
+        moveInProgress = false
+        updateMenuPosition(menuAnchorPosition)
     }
 
 

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelController.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelController.kt
@@ -34,6 +34,7 @@ class HorizontalSidePanelController(
     private val parent: ConstraintLayout,
     private val menuItems: View,
     private val sidePanel: View,
+    private val innerSeparator: View? = null,
 ) {
 
     var currentSide: HorizontalSidePanelSide = HorizontalSidePanelSide.RIGHT
@@ -81,7 +82,28 @@ class HorizontalSidePanelController(
 
             applyTo(parent)
         }
+        applyInnerSeparatorSide(side)
 
         currentSide = side
+    }
+
+    private fun applyInnerSeparatorSide(side: HorizontalSidePanelSide) {
+        val separator = innerSeparator ?: return
+        val sidePanelLayout = sidePanel as? ConstraintLayout ?: return
+
+        ConstraintSet().apply {
+            clone(sidePanelLayout)
+
+            clear(separator.id, ConstraintSet.START)
+            clear(separator.id, ConstraintSet.END)
+
+            if (side == HorizontalSidePanelSide.LEFT) {
+                connect(separator.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+            } else {
+                connect(separator.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+            }
+
+            applyTo(sidePanelLayout)
+        }
     }
 }

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelController.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelController.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common
+
+import android.view.View
+
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
+
+/** Side used to display a panel attached to an overlay menu button cluster. */
+enum class HorizontalSidePanelSide {
+    LEFT,
+    RIGHT,
+}
+
+/**
+ * Moves a side panel before or after the menu buttons inside a single rounded overlay container.
+ */
+class HorizontalSidePanelController(
+    private val parent: ConstraintLayout,
+    private val menuItems: View,
+    private val sidePanel: View,
+) {
+
+    var currentSide: HorizontalSidePanelSide = HorizontalSidePanelSide.RIGHT
+        private set
+
+    fun chooseSide(
+        anchorX: Int,
+        anchorWidth: Int,
+        screenWidth: Int,
+        panelWidth: Int,
+    ): HorizontalSidePanelSide {
+        val rightSpace = screenWidth - anchorX - anchorWidth
+        val leftSpace = anchorX
+
+        return if (
+            rightSpace < panelWidth &&
+            leftSpace >= panelWidth &&
+            leftSpace > rightSpace
+        ) HorizontalSidePanelSide.LEFT
+        else HorizontalSidePanelSide.RIGHT
+    }
+
+    fun applySide(side: HorizontalSidePanelSide) {
+        if (currentSide == side) return
+
+        ConstraintSet().apply {
+            clone(parent)
+
+            clear(menuItems.id, ConstraintSet.START)
+            clear(menuItems.id, ConstraintSet.END)
+            clear(sidePanel.id, ConstraintSet.START)
+            clear(sidePanel.id, ConstraintSet.END)
+
+            if (side == HorizontalSidePanelSide.LEFT) {
+                connect(sidePanel.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+                connect(sidePanel.id, ConstraintSet.END, menuItems.id, ConstraintSet.START)
+                connect(menuItems.id, ConstraintSet.START, sidePanel.id, ConstraintSet.END)
+                connect(menuItems.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+            } else {
+                connect(menuItems.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+                connect(menuItems.id, ConstraintSet.END, sidePanel.id, ConstraintSet.START)
+                connect(sidePanel.id, ConstraintSet.START, menuItems.id, ConstraintSet.END)
+                connect(sidePanel.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+            }
+
+            applyTo(parent)
+        }
+
+        currentSide = side
+    }
+}

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuMoveTouchEventHandler.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuMoveTouchEventHandler.kt
@@ -24,6 +24,8 @@ import android.view.View
 internal class OverlayMenuMoveTouchEventHandler(
     private val onMenuMoved: (Point) -> Unit,
     private val getCurrentMenuPosition: () -> Point,
+    private val onMoveStarted: () -> Unit,
+    private val onMoveFinished: () -> Unit,
 ) {
 
     /** The initial position of the overlay menu when pressing the move menu item. */
@@ -36,11 +38,18 @@ internal class OverlayMenuMoveTouchEventHandler(
             MotionEvent.ACTION_DOWN -> {
                 viewToMove.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                 onDownEvent(viewToMove, event)
+                onMoveStarted()
                 true
             }
 
             MotionEvent.ACTION_MOVE -> {
                 onMoveEvent(event)
+                true
+            }
+
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL -> {
+                onMoveFinished()
                 true
             }
 

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuMoveTouchEventHandler.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuMoveTouchEventHandler.kt
@@ -20,10 +20,10 @@ import android.graphics.Point
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
-import android.view.WindowManager
 
 internal class OverlayMenuMoveTouchEventHandler(
     private val onMenuMoved: (Point) -> Unit,
+    private val getCurrentMenuPosition: () -> Point,
 ) {
 
     /** The initial position of the overlay menu when pressing the move menu item. */
@@ -48,8 +48,7 @@ internal class OverlayMenuMoveTouchEventHandler(
         }
 
     private fun onDownEvent(viewToMove: View, event: MotionEvent) {
-        val layoutParams = (viewToMove.layoutParams as WindowManager.LayoutParams)
-        moveInitialViewPosition = Point(layoutParams.x, layoutParams.y)
+        moveInitialViewPosition = getCurrentMenuPosition()
         moveInitialTouchPosition = Point(event.rawX.toInt(), event.rawY.toInt())
     }
 

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuResizeController.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuResizeController.kt
@@ -94,6 +94,11 @@ internal class OverlayMenuResizeController(
     }
 
     init {
+        backgroundViewGroup.layoutTransition?.setAnimateParentHierarchy(false)
+        (backgroundViewGroup.getChildAt(0) as? ViewGroup)
+            ?.layoutTransition
+            ?.setAnimateParentHierarchy(false)
+        resizedContainer.layoutTransition?.setAnimateParentHierarchy(false)
         resizedContainer.layoutTransition?.addTransitionListener(transitionListener)
     }
 

--- a/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelControllerTests.kt
+++ b/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelControllerTests.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common
+
+import android.os.Build
+import android.view.View
+
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.annotation.Config
+
+/** Test the [HorizontalSidePanelController] class. */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class HorizontalSidePanelControllerTests {
+
+    private val controller = HorizontalSidePanelController(
+        parent = mock(ConstraintLayout::class.java),
+        menuItems = mock(View::class.java),
+        sidePanel = mock(View::class.java),
+    )
+
+    @Test
+    fun chooseSide_whenRightSideFits_returnsRight() {
+        val side = controller.chooseSide(
+            anchorX = 100,
+            anchorWidth = 100,
+            screenWidth = 500,
+            panelWidth = 200,
+        )
+
+        assertEquals(HorizontalSidePanelSide.RIGHT, side)
+    }
+
+    @Test
+    fun chooseSide_whenRightSideDoesNotFitAndLeftSideFitsBetter_returnsLeft() {
+        val side = controller.chooseSide(
+            anchorX = 300,
+            anchorWidth = 100,
+            screenWidth = 500,
+            panelWidth = 200,
+        )
+
+        assertEquals(HorizontalSidePanelSide.LEFT, side)
+    }
+
+    @Test
+    fun chooseSide_whenRightSideDoesNotFitButLeftSideCannotFit_returnsRight() {
+        val side = controller.chooseSide(
+            anchorX = 150,
+            anchorWidth = 100,
+            screenWidth = 300,
+            panelWidth = 200,
+        )
+
+        assertEquals(HorizontalSidePanelSide.RIGHT, side)
+    }
+
+    @Test
+    fun chooseSide_whenRightSideDoesNotFitButLeftSideIsWorse_returnsRight() {
+        val side = controller.chooseSide(
+            anchorX = 150,
+            anchorWidth = 100,
+            screenWidth = 260,
+            panelWidth = 120,
+        )
+
+        assertEquals(HorizontalSidePanelSide.RIGHT, side)
+    }
+}

--- a/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelControllerTests.kt
+++ b/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/HorizontalSidePanelControllerTests.kt
@@ -76,12 +76,12 @@ class HorizontalSidePanelControllerTests {
     }
 
     @Test
-    fun chooseSide_whenRightSideDoesNotFitButLeftSideIsWorse_returnsRight() {
+    fun chooseSide_whenRightSideFitsEvenIfLeftSideHasRoom_returnsRight() {
         val side = controller.chooseSide(
-            anchorX = 150,
+            anchorX = 300,
             anchorWidth = 100,
-            screenWidth = 260,
-            panelWidth = 120,
+            screenWidth = 800,
+            panelWidth = 200,
         )
 
         assertEquals(HorizontalSidePanelSide.RIGHT, side)

--- a/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuMoveTouchEventHandlerTests.kt
+++ b/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuMoveTouchEventHandlerTests.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common
+
+import android.graphics.Point
+import android.os.Build
+import android.view.MotionEvent
+import android.view.View
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import com.buzbuz.smartautoclicker.core.common.overlays.testutils.mockSimpleRawEvent
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.annotation.Config
+
+/** Test the [OverlayMenuMoveTouchEventHandler] class. */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class OverlayMenuMoveTouchEventHandlerTests {
+
+    @Test
+    fun onTouchEvent_onActionUp_notifiesMoveFinished() {
+        var moveFinishedCount = 0
+        val handler = newHandler(
+            onMoveFinished = { moveFinishedCount++ },
+        )
+
+        handler.onTouchEvent(mock(View::class.java), mockSimpleRawEvent(MotionEvent.ACTION_UP, 0f, 0f))
+
+        assertEquals(1, moveFinishedCount)
+    }
+
+    @Test
+    fun onTouchEvent_onActionCancel_notifiesMoveFinished() {
+        var moveFinishedCount = 0
+        val handler = newHandler(
+            onMoveFinished = { moveFinishedCount++ },
+        )
+
+        handler.onTouchEvent(mock(View::class.java), mockSimpleRawEvent(MotionEvent.ACTION_CANCEL, 0f, 0f))
+
+        assertEquals(1, moveFinishedCount)
+    }
+
+    @Test
+    fun onTouchEvent_onActionMove_usesLogicalMenuPosition() {
+        var movedPosition: Point? = null
+        val handler = newHandler(
+            getCurrentMenuPosition = { Point(200, 100) },
+            onMenuMoved = { movedPosition = it },
+        )
+        val movedView = mock(View::class.java)
+
+        handler.onTouchEvent(movedView, mockSimpleRawEvent(MotionEvent.ACTION_DOWN, 20f, 20f))
+        handler.onTouchEvent(movedView, mockSimpleRawEvent(MotionEvent.ACTION_MOVE, 50f, 40f))
+
+        assertEquals(Point(230, 120), movedPosition)
+    }
+
+    private fun newHandler(
+        onMenuMoved: (Point) -> Unit = {},
+        getCurrentMenuPosition: () -> Point = { Point(0, 0) },
+        onMoveStarted: () -> Unit = {},
+        onMoveFinished: () -> Unit = {},
+    ): OverlayMenuMoveTouchEventHandler =
+        OverlayMenuMoveTouchEventHandler(
+            onMenuMoved = onMenuMoved,
+            getCurrentMenuPosition = getCurrentMenuPosition,
+            onMoveStarted = onMoveStarted,
+            onMoveFinished = onMoveFinished,
+        )
+}

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
@@ -110,6 +110,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             parent = viewBinding.layoutDebug.parent as ConstraintLayout,
             menuItems = viewBinding.menuItems,
             sidePanel = viewBinding.layoutDebug,
+            innerSeparator = viewBinding.separatorStart,
         )
 
         return viewBinding.root

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
@@ -213,12 +213,14 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
 
         val anchorWidth = getMenuAnchorWidth(windowSize)
         val panelWidth = (windowSize.width - anchorWidth).coerceAtLeast(0)
-        val side = chooseHorizontalSidePanelSide(
-            anchorPosition = anchorPosition,
-            anchorWidth = anchorWidth,
-            panelWidth = panelWidth,
-            sidePanelController = debugSidePanelController,
-        )
+        val side = if (shouldRefreshSidePanelPlacement()) {
+            chooseHorizontalSidePanelSide(
+                anchorPosition = anchorPosition,
+                anchorWidth = anchorWidth,
+                panelWidth = panelWidth,
+                sidePanelController = debugSidePanelController,
+            )
+        } else debugSidePanelController.currentSide
 
         debugSidePanelController.applySide(side)
         return if (side == HorizontalSidePanelSide.LEFT) {

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
@@ -23,6 +23,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.View
 
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -32,6 +33,8 @@ import com.buzbuz.smartautoclicker.core.base.isStopScenarioKey
 import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
 import com.buzbuz.smartautoclicker.core.common.overlays.manager.OverlayManager.Companion.showAsOverlay
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.OverlayMenu
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelController
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelSide
 import com.buzbuz.smartautoclicker.core.ui.utils.AnimatedStatesImageButtonController
 import com.buzbuz.smartautoclicker.core.ui.utils.getDynamicColorsContext
 import com.buzbuz.smartautoclicker.feature.smart.config.R
@@ -79,6 +82,8 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
     private lateinit var viewBinding: OverlayMenuBinding
     /** Controls the animations of the play/pause button. */
     private lateinit var playPauseButtonController: AnimatedStatesImageButtonController
+    /** Controls the position of the debug panel around the menu buttons. */
+    private lateinit var debugSidePanelController: HorizontalSidePanelController
     /** Adapter upon actions being executed while in live debugging. */
     private val debugLiveActionsAdapter: LiveDebuggingActionsAdapter = LiveDebuggingActionsAdapter()
 
@@ -101,6 +106,11 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
         )
         viewBinding = OverlayMenuBinding.inflate(layoutInflater)
         playPauseButtonController.attachView(viewBinding.btnPlay)
+        debugSidePanelController = HorizontalSidePanelController(
+            parent = viewBinding.layoutDebug.parent as ConstraintLayout,
+            menuItems = viewBinding.menuItems,
+            sidePanel = viewBinding.layoutDebug,
+        )
 
         return viewBinding.root
     }
@@ -190,6 +200,30 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_panel_width),
             bgSize.height,
         )
+    }
+
+    override fun getMenuAnchorWidth(windowSize: Size): Int =
+        viewBinding.menuItems.width.takeIf { it > 0 } ?: super.getMenuAnchorWidth(windowSize)
+
+    override fun onMenuAnchorPositionUpdated(anchorPosition: android.graphics.Point, windowSize: Size): android.graphics.Point {
+        if (viewBinding.layoutDebug.visibility != View.VISIBLE) {
+            debugSidePanelController.applySide(HorizontalSidePanelSide.RIGHT)
+            return anchorPosition
+        }
+
+        val anchorWidth = getMenuAnchorWidth(windowSize)
+        val panelWidth = (windowSize.width - anchorWidth).coerceAtLeast(0)
+        val side = chooseHorizontalSidePanelSide(
+            anchorPosition = anchorPosition,
+            anchorWidth = anchorWidth,
+            panelWidth = panelWidth,
+            sidePanelController = debugSidePanelController,
+        )
+
+        debugSidePanelController.applySide(side)
+        return if (side == HorizontalSidePanelSide.LEFT) {
+            android.graphics.Point(anchorPosition.x - panelWidth, anchorPosition.y)
+        } else anchorPosition
     }
 
     fun onMediaProjectionLost() {
@@ -282,6 +316,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
     private fun updateDebugOverlayViewVisibility(isVisible: Boolean) {
         if (isVisible && debugObservableJob == null) {
             viewBinding.layoutDebug.visibility = View.VISIBLE
+            refreshMenuLayout()
             debugObservableJob = observeDebugValues()
 
         } else if (!isVisible && debugObservableJob != null) {
@@ -290,6 +325,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
 
             updateLiveDebugUiState(null)
             viewBinding.layoutDebug.visibility = View.GONE
+            refreshMenuLayout()
         }
     }
 

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/conditiontry/TryImageConditionOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/conditiontry/TryImageConditionOverlayMenu.kt
@@ -103,7 +103,7 @@ class TryImageConditionOverlayMenu(
     override fun getWindowMaximumSize(backgroundView: ViewGroup): Size {
         val bgSize = super.getWindowMaximumSize(backgroundView)
         return Size(
-            bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_text_width),
+            bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_image_condition_try_panel_width),
             bgSize.height,
         )
     }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/conditiontry/TryImageConditionOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/conditiontry/TryImageConditionOverlayMenu.kt
@@ -114,12 +114,14 @@ class TryImageConditionOverlayMenu(
     override fun onMenuAnchorPositionUpdated(anchorPosition: Point, windowSize: Size): Point {
         val anchorWidth = getMenuAnchorWidth(windowSize)
         val panelWidth = (windowSize.width - anchorWidth).coerceAtLeast(0)
-        val side = chooseHorizontalSidePanelSide(
-            anchorPosition = anchorPosition,
-            anchorWidth = anchorWidth,
-            panelWidth = panelWidth,
-            sidePanelController = debugSidePanelController,
-        )
+        val side = if (shouldRefreshSidePanelPlacement()) {
+            chooseHorizontalSidePanelSide(
+                anchorPosition = anchorPosition,
+                anchorWidth = anchorWidth,
+                panelWidth = panelWidth,
+                sidePanelController = debugSidePanelController,
+            )
+        } else debugSidePanelController.currentSide
 
         debugSidePanelController.applySide(side)
         return if (side == HorizontalSidePanelSide.LEFT) Point(anchorPosition.x - panelWidth, anchorPosition.y)

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/conditiontry/TryImageConditionOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/conditiontry/TryImageConditionOverlayMenu.kt
@@ -16,11 +16,13 @@
  */
 package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.live.conditiontry
 
+import android.graphics.Point
 import android.util.Size
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -28,6 +30,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.buzbuz.smartautoclicker.core.base.isStopScenarioKey
 import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.OverlayMenu
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelController
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelSide
 import com.buzbuz.smartautoclicker.core.domain.model.condition.ImageCondition
 import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.feature.smart.debugging.R
@@ -52,6 +56,9 @@ class TryImageConditionOverlayMenu(
         creator = { tryImageConditionViewModel() },
     )
 
+    /** Controls the position of the debug panel around the menu buttons. */
+    private lateinit var debugSidePanelController: HorizontalSidePanelController
+
     private lateinit var viewBinding: OverlayTryImageConditionMenuBinding
 
     override fun onCreateMenu(layoutInflater: LayoutInflater): ViewGroup {
@@ -66,6 +73,11 @@ class TryImageConditionOverlayMenu(
                 })
             }
         }
+        debugSidePanelController = HorizontalSidePanelController(
+            parent = viewBinding.layoutResult.parent as ConstraintLayout,
+            menuItems = viewBinding.menuItems,
+            sidePanel = viewBinding.layoutResult,
+        )
 
         return viewBinding.root
     }
@@ -94,6 +106,24 @@ class TryImageConditionOverlayMenu(
             bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_text_width),
             bgSize.height,
         )
+    }
+
+    override fun getMenuAnchorWidth(windowSize: Size): Int =
+        viewBinding.menuItems.width.takeIf { it > 0 } ?: super.getMenuAnchorWidth(windowSize)
+
+    override fun onMenuAnchorPositionUpdated(anchorPosition: Point, windowSize: Size): Point {
+        val anchorWidth = getMenuAnchorWidth(windowSize)
+        val panelWidth = (windowSize.width - anchorWidth).coerceAtLeast(0)
+        val side = chooseHorizontalSidePanelSide(
+            anchorPosition = anchorPosition,
+            anchorWidth = anchorWidth,
+            panelWidth = panelWidth,
+            sidePanelController = debugSidePanelController,
+        )
+
+        debugSidePanelController.applySide(side)
+        return if (side == HorizontalSidePanelSide.LEFT) Point(anchorPosition.x - panelWidth, anchorPosition.y)
+        else anchorPosition
     }
 
     override fun onMenuItemClicked(viewId: Int) {

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
@@ -16,12 +16,14 @@
  */
 package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.live.eventtry
 
+import android.graphics.Point
 import android.util.Size
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -31,6 +33,8 @@ import com.buzbuz.smartautoclicker.core.base.isStopScenarioKey
 import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
 import com.buzbuz.smartautoclicker.core.common.overlays.menu.OverlayMenu
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelController
+import com.buzbuz.smartautoclicker.core.common.overlays.menu.implementation.common.HorizontalSidePanelSide
 import com.buzbuz.smartautoclicker.core.domain.model.event.ImageEvent
 import com.buzbuz.smartautoclicker.feature.smart.debugging.R
 import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.OverlayTryEventMenuBinding
@@ -53,12 +57,19 @@ class TryEventOverlayMenu(
 
     /** Adapter upon actions being executed while in live debugging. */
     private val tryEventActionsAdapter: TryEventActionsAdapter = TryEventActionsAdapter()
+    /** Controls the position of the debug panel around the menu buttons. */
+    private lateinit var debugSidePanelController: HorizontalSidePanelController
 
     private lateinit var viewBinding: OverlayTryEventMenuBinding
 
     override fun onCreateMenu(layoutInflater: LayoutInflater): ViewGroup {
         viewBinding = OverlayTryEventMenuBinding.inflate(LayoutInflater.from(context))
         viewBinding.actionList.adapter = tryEventActionsAdapter
+        debugSidePanelController = HorizontalSidePanelController(
+            parent = viewBinding.layoutDebug.parent as ConstraintLayout,
+            menuItems = viewBinding.menuItems,
+            sidePanel = viewBinding.layoutDebug,
+        )
 
         return viewBinding.root
     }
@@ -85,6 +96,24 @@ class TryEventOverlayMenu(
             bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_text_width),
             bgSize.height,
         )
+    }
+
+    override fun getMenuAnchorWidth(windowSize: Size): Int =
+        viewBinding.menuItems.width.takeIf { it > 0 } ?: super.getMenuAnchorWidth(windowSize)
+
+    override fun onMenuAnchorPositionUpdated(anchorPosition: Point, windowSize: Size): Point {
+        val anchorWidth = getMenuAnchorWidth(windowSize)
+        val panelWidth = (windowSize.width - anchorWidth).coerceAtLeast(0)
+        val side = chooseHorizontalSidePanelSide(
+            anchorPosition = anchorPosition,
+            anchorWidth = anchorWidth,
+            panelWidth = panelWidth,
+            sidePanelController = debugSidePanelController,
+        )
+
+        debugSidePanelController.applySide(side)
+        return if (side == HorizontalSidePanelSide.LEFT) Point(anchorPosition.x - panelWidth, anchorPosition.y)
+        else anchorPosition
     }
 
     override fun onMenuItemClicked(viewId: Int) {

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
@@ -69,6 +69,7 @@ class TryEventOverlayMenu(
             parent = viewBinding.layoutDebug.parent as ConstraintLayout,
             menuItems = viewBinding.menuItems,
             sidePanel = viewBinding.layoutDebug,
+            innerSeparator = viewBinding.separatorStart,
         )
 
         return viewBinding.root

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
@@ -104,12 +104,14 @@ class TryEventOverlayMenu(
     override fun onMenuAnchorPositionUpdated(anchorPosition: Point, windowSize: Size): Point {
         val anchorWidth = getMenuAnchorWidth(windowSize)
         val panelWidth = (windowSize.width - anchorWidth).coerceAtLeast(0)
-        val side = chooseHorizontalSidePanelSide(
-            anchorPosition = anchorPosition,
-            anchorWidth = anchorWidth,
-            panelWidth = panelWidth,
-            sidePanelController = debugSidePanelController,
-        )
+        val side = if (shouldRefreshSidePanelPlacement()) {
+            chooseHorizontalSidePanelSide(
+                anchorPosition = anchorPosition,
+                anchorWidth = anchorWidth,
+                panelWidth = panelWidth,
+                sidePanelController = debugSidePanelController,
+            )
+        } else debugSidePanelController.currentSide
 
         debugSidePanelController.applySide(side)
         return if (side == HorizontalSidePanelSide.LEFT) Point(anchorPosition.x - panelWidth, anchorPosition.y)

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/live/eventtry/TryEventOverlayMenu.kt
@@ -94,7 +94,7 @@ class TryEventOverlayMenu(
     override fun getWindowMaximumSize(backgroundView: ViewGroup): Size {
         val bgSize = super.getWindowMaximumSize(backgroundView)
         return Size(
-            bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_text_width),
+            bgSize.width + context.resources.getDimensionPixelSize(R.dimen.overlay_debug_event_try_panel_width),
             bgSize.height,
         )
     }

--- a/feature/smart-debugging/src/main/res/layout/overlay_try_image_condition_menu.xml
+++ b/feature/smart-debugging/src/main/res/layout/overlay_try_image_condition_menu.xml
@@ -65,7 +65,7 @@
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_result"
-                android:layout_width="275dp"
+                android:layout_width="@dimen/overlay_debug_image_condition_try_panel_width"
                 android:layout_height="0dp"
                 android:layout_marginStart="@dimen/margin_horizontal_small"
                 android:layout_marginEnd="@dimen/margin_horizontal_mini"

--- a/feature/smart-debugging/src/main/res/values/dimens.xml
+++ b/feature/smart-debugging/src/main/res/values/dimens.xml
@@ -18,7 +18,7 @@
 <resources>
     <dimen name="overlay_debug_event_try_panel_width">200dp</dimen>
     <dimen name="overlay_debug_event_try_panel_height">140dp</dimen>
-    <dimen name="overlay_debug_text_width">150dp</dimen>
+    <dimen name="overlay_debug_image_condition_try_panel_width">275dp</dimen>
     <dimen name="dialog_debug_condition_icons_height">30dp</dimen>
     <dimen name="dialog_debug_condition_bitmap_size">100dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary

Fixes #850.

This PR makes horizontal debug/result panels choose a side around the floating overlay buttons instead of always assuming that the panel can open to the right.

It applies to:

- the main running toolbar live debug panel
- the try-event live debug panel
- the try-image-condition result/threshold panel

## Behavior

Right-side placement remains the default. The panel flips left only when all of these are true:

- the panel cannot fully fit on the right side of the button cluster
- the panel can fully fit on the left side
- the left side has more available room than the right side

When the panel flips left, the button cluster remains the user's visual anchor. The overlay window shifts left so the buttons stay where the user placed them.

## Other Details

- Placement is rechecked after the user releases the move button, not continuously during drag.
- The stored overlay position remains the logical button-cluster anchor, not the shifted left-panel window edge.
- The panel is reordered inside the same rounded `CardView` rather than split into a second overlay window.
- Debug separators move to the inner edge when the panel is on the left.
- Try-event and try-image-condition placement calculations now use the actual panel widths from their layouts.

## Animation Caveat

This improves the clipping/placement logic and reduces a few right-side assumptions in the transition path. The resize animation may still benefit from maintainer-side visual tuning on a real device: when the panel is on the left and the buttons are anchored on the right, Android's layout-change transition can still feel like it is folding from the larger debug panel instead of perfectly from the button anchor. I am calling this out because the mechanical placement behavior is covered here, while the final motion polish is much easier to judge with live overlay feedback.

## Validation

- `./gradlew.bat --no-daemon --max-workers=3 --console=plain :core:common:overlays:testFDroidDebugUnitTest :feature:smart-config:compileFDroidDebugKotlin :feature:smart-debugging:compileFDroidDebugKotlin`
