### PR TITLE
Overlay passthrough during runtime live debug panel

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
@@ -29,6 +29,7 @@ import android.view.View
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.view.ViewTreeObserver
 import android.widget.ImageButton
 
 import androidx.annotation.CallSuper
@@ -115,9 +116,9 @@ abstract class OverlayMenu(
     /** The root view of the menu overlay. Retrieved from [onCreateMenu] implementation. */
     private lateinit var menuLayout: ViewGroup
     /** The view displaying the background of the overlay. */
-    private lateinit var menuBackground: ViewGroup
+    protected lateinit var menuBackground: ViewGroup
     /** The view containing the buttons as direct children. */
-    private lateinit var buttonsContainer: ViewGroup
+    protected lateinit var buttonsContainer: ViewGroup
     /** Handles the window size computing when animating a resize of the overlay. */
     private lateinit var resizeController: OverlayMenuResizeController
     /** Handles the touch events on the move button. */
@@ -145,6 +146,85 @@ abstract class OverlayMenu(
     protected var screenOverlayView: View? = null
     /** The layout parameters of the overlay view. */
     private lateinit var overlayLayoutParams: WindowManager.LayoutParams
+    private var originalOverlayFlags: Int = 0
+    private var isWindowStarted: Boolean = false
+    private var forceWindowPassthrough: Boolean = false
+
+    private var internalInsetsListenerProxy: Any? = null
+
+    private fun setupInternalInsetsListener() {
+        if (internalInsetsListenerProxy != null) return
+        try {
+            val listenerClass = Class.forName("android.view.ViewTreeObserver\$OnComputeInternalInsetsListener")
+            val touchableRegionField = Class.forName("android.view.ViewTreeObserver\$InternalInsetsInfo").getField("touchableRegion")
+            val setTouchableInsetsMethod = Class.forName("android.view.ViewTreeObserver\$InternalInsetsInfo").getMethod("setTouchableInsets", java.lang.Integer.TYPE)
+
+            val proxy = java.lang.reflect.Proxy.newProxyInstance(
+                listenerClass.classLoader,
+                arrayOf(listenerClass)
+            ) { _, method, args ->
+                if (method.name == "onComputeInternalInsets") {
+                    val insetsInfo = args[0]
+                    val region = touchableRegionField.get(insetsInfo) as android.graphics.Region
+                    region.setEmpty()
+
+                    getTouchableViews().forEach { view ->
+                        if (view.visibility == View.VISIBLE && view.isAttachedToWindow) {
+                            val rect = android.graphics.Rect()
+                            view.getDrawingRect(rect)
+                            try {
+                                menuLayout.offsetDescendantRectToMyCoords(view, rect)
+                                region.union(rect)
+                            } catch (e: IllegalArgumentException) {
+                                // Descendant view is not a child of menuLayout
+                            }
+                        }
+                    }
+
+                    setTouchableInsetsMethod.invoke(insetsInfo, TOUCHABLE_INSETS_REGION)
+                }
+                null
+            }
+
+            val addMethod = ViewTreeObserver::class.java.getMethod("addOnComputeInternalInsetsListener", listenerClass)
+            addMethod.invoke(menuLayout.viewTreeObserver, proxy)
+            internalInsetsListenerProxy = proxy
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to setup OnComputeInternalInsetsListener via reflection", e)
+        }
+    }
+
+    private fun removeInternalInsetsListener() {
+        val proxy = internalInsetsListenerProxy ?: return
+        try {
+            val listenerClass = Class.forName("android.view.ViewTreeObserver\$OnComputeInternalInsetsListener")
+            val removeMethod = ViewTreeObserver::class.java.getMethod("removeOnComputeInternalInsetsListener", listenerClass)
+            removeMethod.invoke(menuLayout.viewTreeObserver, proxy)
+            internalInsetsListenerProxy = null
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to remove OnComputeInternalInsetsListener via reflection", e)
+        }
+    }
+
+    private fun updateInternalInsetsListener() {
+        if (!this::menuLayout.isInitialized || !menuLayout.isAttachedToWindow) return
+
+        if (shouldUseTouchableInsets()) {
+            setupInternalInsetsListener()
+            menuLayout.requestLayout()
+        } else {
+            removeInternalInsetsListener()
+        }
+    }
+
+    protected open fun getTouchableViews(): List<View> {
+        return listOf(buttonsContainer)
+    }
+
+    protected open fun shouldUseTouchableInsets(): Boolean = false
+
+    protected open fun shouldForceNotTouchableOnGestureDispatch(): Boolean = false
 
     private val onLockedPositionChangedListener: (Point?) -> Unit = ::onLockedPositionChanged
 
@@ -194,11 +274,23 @@ abstract class OverlayMenu(
         menuLayout = onCreateMenu(context.getSystemService(LayoutInflater::class.java))
         screenOverlayView = onCreateOverlayView()
         overlayLayoutParams = onCreateOverlayViewLayoutParams()
+        originalOverlayFlags = overlayLayoutParams.flags
 
         // Set the clicks listener on the menu items
         menuBackground = menuLayout.findViewById(R.id.menu_background)
         buttonsContainer = menuLayout.findViewById(R.id.menu_items)
         setupButtons(buttonsContainer)
+
+        // Add the attach listener to set up the insets listener when attached to the window
+        menuLayout.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                updateInternalInsetsListener()
+            }
+
+            override fun onViewDetachedFromWindow(v: View) {
+                removeInternalInsetsListener()
+            }
+        })
 
         // Setup the touch event handler for the move button
         moveTouchEventHandler = OverlayMenuMoveTouchEventHandler(::updateMenuPosition)
@@ -263,6 +355,10 @@ abstract class OverlayMenu(
         super.start()
         loadMenuPosition(displayConfigManager.displayConfig.orientation)
 
+        isWindowStarted = true
+        applyWindowTouchability()
+        updateInternalInsetsListener()
+
         // Start the show animation for the menu
         Log.d(TAG, "Start show overlay ${hashCode()} animation...")
 
@@ -313,6 +409,9 @@ abstract class OverlayMenu(
             screenOverlayView?.visibility = View.GONE
 
             super.stop()
+            isWindowStarted = false
+            applyWindowTouchability()
+            updateInternalInsetsListener()
 
             if (destroyOnceHidden) {
                 destroyOnceHidden = false
@@ -335,6 +434,7 @@ abstract class OverlayMenu(
         positionDataSource.removeOnLockedPositionChangedListener(onLockedPositionChangedListener)
         saveMenuPosition(displayConfigManager.displayConfig.orientation)
 
+        removeInternalInsetsListener()
         windowManager.removeView(menuLayout)
         screenOverlayView?.let { windowManager.removeView(it) }
         screenOverlayView = null
@@ -420,6 +520,11 @@ abstract class OverlayMenu(
      * @param isVisible true if it has became visible, false if it became invisible.
      */
     protected open fun onScreenOverlayVisibilityChanged(isVisible: Boolean): Unit = Unit
+
+    protected fun refreshTouchHandling() {
+        updateInternalInsetsListener()
+        applyWindowTouchability()
+    }
 
     /**
      * Get the maximum size the window can take.
@@ -522,6 +627,7 @@ abstract class OverlayMenu(
                 hideOverlayButton?.setImageResource(R.drawable.ic_visible_off)
             }
 
+            refreshTouchHandling()
             onScreenOverlayVisibilityChanged(isOverlayVisible)
         }
     }
@@ -605,7 +711,50 @@ abstract class OverlayMenu(
             positionDataSource.dump(writer, contentPrefix)
         }
     }
+
+    private fun applyWindowTouchability() {
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) return
+
+        val shouldForceNotTouchable = forceWindowPassthrough && shouldForceNotTouchableOnGestureDispatch()
+        val menuFlags = if (isWindowStarted && !shouldForceNotTouchable) {
+            menuLayoutParams.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE.inv()
+        } else {
+            menuLayoutParams.flags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+        }
+
+        if (menuLayoutParams.flags != menuFlags) {
+            menuLayoutParams.flags = menuFlags
+        }
+        if (menuLayout.isAttachedToWindow) {
+            windowManager.safeUpdateViewLayout(menuLayout, menuLayoutParams)
+        }
+
+        screenOverlayView?.let { view ->
+            val overlayFlags = when {
+                !isWindowStarted || shouldForceNotTouchable || view.visibility != View.VISIBLE ->
+                    overlayLayoutParams.flags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+
+                else -> originalOverlayFlags
+            }
+
+            if (overlayLayoutParams.flags != overlayFlags) {
+                overlayLayoutParams.flags = overlayFlags
+            }
+            if (view.isAttachedToWindow) {
+                windowManager.safeUpdateViewLayout(view, overlayLayoutParams)
+            }
+        }
+    }
+
+    fun setWindowTouchable(touchable: Boolean) {
+        val shouldForceWindowPassthrough = !touchable && shouldForceNotTouchableOnGestureDispatch()
+        if (forceWindowPassthrough == shouldForceWindowPassthrough) return
+
+        forceWindowPassthrough = shouldForceWindowPassthrough
+        applyWindowTouchability()
+    }
 }
 
 /** Tag for logs */
 private const val TAG = "OverlayMenu"
+private const val TOUCHABLE_INSETS_REGION = 3

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
@@ -56,8 +56,8 @@ import kotlinx.coroutines.launch
  * once the user has selected a scenario to be used. It allows the user to start the detection on the currently loaded
  * scenario, as well as editing the attached list of events.
  *
- * There is no overlay views attached to this overlay menu, meaning that the user will always be able to clicks on the
- * Activities displayed below it.
+ * The debug panel is informational and should let the user interact with the app underneath while a scenario is
+ * running.
  */
 class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
 
@@ -84,6 +84,8 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
 
     /** The coroutine job for the observable used in debug mode. Null when not in debug mode. */
     private var debugObservableJob: Job? = null
+    private var isScenarioRunning: Boolean = false
+    private var isDebugPanelVisible: Boolean = false
 
     /**
      * Tells if this service has handled onKeyEvent with ACTION_DOWN for a key in order to return
@@ -131,6 +133,10 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             }
         }
     }
+
+    override fun shouldUseTouchableInsets(): Boolean = shouldUseRuntimeDebugPassthrough()
+
+    override fun shouldForceNotTouchableOnGestureDispatch(): Boolean = shouldUseRuntimeDebugPassthrough()
 
     override fun onStart() {
         super.onStart()
@@ -231,6 +237,8 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
     /** Refresh the menu layout according to the detection state. */
     private fun updateDetectionState(newState: UiState) {
         val currentState = viewBinding.btnPlay.tag
+        isScenarioRunning = newState == UiState.Detecting
+        refreshTouchHandling()
         if (currentState == newState) return
 
         viewBinding.btnPlay.tag = newState
@@ -280,6 +288,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
      * @param isVisible true when the debug view should be shown, false to hide it.
      */
     private fun updateDebugOverlayViewVisibility(isVisible: Boolean) {
+        isDebugPanelVisible = isVisible
         if (isVisible && debugObservableJob == null) {
             viewBinding.layoutDebug.visibility = View.VISIBLE
             debugObservableJob = observeDebugValues()
@@ -291,7 +300,12 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             updateLiveDebugUiState(null)
             viewBinding.layoutDebug.visibility = View.GONE
         }
+
+        refreshTouchHandling()
     }
+
+    private fun shouldUseRuntimeDebugPassthrough(): Boolean =
+        isScenarioRunning && isDebugPanelVisible
 
     /**
      * Observe the values for the debug and update the debug views.


### PR DESCRIPTION
This narrows overlay touch passthrough to the specific runtime case where it is useful: the smart `MainMenu` while scenario detection is running and the live debug panel is visible.

What changed:
- moves passthrough shaping in `OverlayMenu` from shared default behavior to an explicit opt-in path
- opts in only the smart runtime `MainMenu`
- keeps the floating action/button cluster touchable
- lets the informational live debug panel stay visible without blocking the app underneath
- leaves other overlays on their default interaction model instead of making them implicitly passthrough

Why this revision:
- the previous implementation was too broad because it made shared `OverlayMenu` touchability/insets behavior apply across many overlay UIs
- that caused unintended passthrough behavior outside the runtime live-debug case
- this version keeps passthrough focused on the normal running-scenario debug surface only

Implementation notes:
- `OverlayMenu` now exposes a small opt-in hook for touchable insets / gesture-dispatch passthrough shaping
- `MainMenu` enables it only when the scenario is actively running and the debug panel is shown
- no fork-specific branding, release, or patched-package changes are included

Validation:
- built the F-Droid debug APK locally from this branch
- installed and manually verified on device that the debug side panel no longer blocks the underlying app during normal runtime
- confirmed the narrowed passthrough behavior matches the intended runtime-only use case