### PR TITLE
Add saturation-drop validation to image matching

### DIFF
--- a/core/smart/detection/src/main/cpp/detector/matching/template_matcher.cpp
+++ b/core/smart/detection/src/main/cpp/detector/matching/template_matcher.cpp
@@ -25,6 +25,10 @@
 
 using namespace smartautoclicker;
 
+static constexpr int MIN_COLORFUL_SATURATION = 128;
+static constexpr int MIN_COLORFUL_VALUE = 40;
+static constexpr double MIN_COLORFUL_PIXEL_RATIO = 0.05;
+
 
 void TemplateMatcher::reset() {
     currentMatchingResult.reset();
@@ -107,15 +111,23 @@ void TemplateMatcher::parseMatchingResult(
 
         // Check if the colors are matching in the candidate area.
         cv::Mat fullSizeColorCroppedCurrentImage = screenImage.cropColor(currentMatchingResult.getResultArea());
-        double colorDiff = getColorDiff(fullSizeColorCroppedCurrentImage,condition.getColorMean());
 
         // If the colors are OK, the result is valid
-        if (colorDiff < threshold) currentMatchingResult.markResultAsDetected();
+        if (isColorValid(fullSizeColorCroppedCurrentImage, condition, threshold)) {
+            currentMatchingResult.markResultAsDetected();
+        }
     }
 }
 
 bool TemplateMatcher::isConfidenceValid(double confidence, int threshold) {
     return confidence > ((100.0 - threshold) / 100.0);
+}
+
+bool TemplateMatcher::isColorValid(const cv::Mat& image, const ConditionImage& condition, int threshold) {
+    double colorDiffThreshold = static_cast<double>(threshold);
+
+    return getColorDiff(image, condition.getColorMean()) < colorDiffThreshold
+           && getSaturationDropDiff(image, *condition.getColorMat()) < colorDiffThreshold;
 }
 
 double TemplateMatcher::getColorDiff(const cv::Mat& image, const cv::Scalar& conditionColorMeans) {
@@ -126,4 +138,40 @@ double TemplateMatcher::getColorDiff(const cv::Mat& image, const cv::Scalar& con
        diff += abs(imageColorMeans.val[i] - conditionColorMeans.val[i]);
    }
    return (diff * 100) / (255 * 3);
+}
+
+double TemplateMatcher::getSaturationDropDiff(const cv::Mat& image, const cv::Mat& condition) {
+    cv::Mat imageRgb;
+    cv::Mat conditionRgb;
+    cv::cvtColor(image, imageRgb, cv::COLOR_RGBA2RGB);
+    cv::cvtColor(condition, conditionRgb, cv::COLOR_RGBA2RGB);
+
+    cv::Mat imageHsv;
+    cv::Mat conditionHsv;
+    cv::cvtColor(imageRgb, imageHsv, cv::COLOR_RGB2HSV);
+    cv::cvtColor(conditionRgb, conditionHsv, cv::COLOR_RGB2HSV);
+
+    cv::Mat imageSaturation;
+    cv::Mat conditionSaturation;
+    cv::Mat conditionValue;
+    cv::extractChannel(imageHsv, imageSaturation, 1);
+    cv::extractChannel(conditionHsv, conditionSaturation, 1);
+    cv::extractChannel(conditionHsv, conditionValue, 2);
+
+    cv::Mat colorfulSaturationMask;
+    cv::Mat colorfulValueMask;
+    cv::compare(conditionSaturation, MIN_COLORFUL_SATURATION, colorfulSaturationMask, cv::CMP_GT);
+    cv::compare(conditionValue, MIN_COLORFUL_VALUE, colorfulValueMask, cv::CMP_GT);
+
+    cv::Mat colorfulMask;
+    cv::bitwise_and(colorfulSaturationMask, colorfulValueMask, colorfulMask);
+
+    int colorfulPixels = cv::countNonZero(colorfulMask);
+    double minColorfulPixels = condition.total() * MIN_COLORFUL_PIXEL_RATIO;
+    if (colorfulPixels < minColorfulPixels) return 0;
+
+    cv::Mat saturationDrop;
+    cv::subtract(conditionSaturation, imageSaturation, saturationDrop, colorfulMask);
+
+    return (cv::mean(saturationDrop, colorfulMask).val[0] * 100) / 255;
 }

--- a/core/smart/detection/src/main/cpp/detector/matching/template_matcher.cpp
+++ b/core/smart/detection/src/main/cpp/detector/matching/template_matcher.cpp
@@ -28,6 +28,7 @@ using namespace smartautoclicker;
 static constexpr int MIN_COLORFUL_SATURATION = 128;
 static constexpr int MIN_COLORFUL_VALUE = 40;
 static constexpr double MIN_COLORFUL_PIXEL_RATIO = 0.05;
+static constexpr double SATURATION_DROP_THRESHOLD = 20.0;
 
 
 void TemplateMatcher::reset() {
@@ -127,7 +128,7 @@ bool TemplateMatcher::isColorValid(const cv::Mat& image, const ConditionImage& c
     double colorDiffThreshold = static_cast<double>(threshold);
 
     return getColorDiff(image, condition.getColorMean()) < colorDiffThreshold
-           && getSaturationDropDiff(image, *condition.getColorMat()) < colorDiffThreshold;
+           && getSaturationDropDiff(image, *condition.getColorMat()) < SATURATION_DROP_THRESHOLD;
 }
 
 double TemplateMatcher::getColorDiff(const cv::Mat& image, const cv::Scalar& conditionColorMeans) {

--- a/core/smart/detection/src/main/cpp/detector/matching/template_matcher.hpp
+++ b/core/smart/detection/src/main/cpp/detector/matching/template_matcher.hpp
@@ -39,7 +39,9 @@ namespace smartautoclicker {
                 cv::Mat& matchingResult);
 
         static bool isConfidenceValid(double confidence, int threshold);
+        static bool isColorValid(const cv::Mat& image, const ConditionImage& condition, int threshold);
         static double getColorDiff(const cv::Mat& image, const cv::Scalar& conditionColorMeans);
+        static double getSaturationDropDiff(const cv::Mat& image, const cv::Mat& condition);
 
     public:
         void reset();


### PR DESCRIPTION
Fixes #865.

## Summary
This adds a saturation-drop validation step to template matching so candidates can be rejected when they keep a strong grayscale match but lose the meaningful color present in the saved condition image.

## Why
The current matcher is grayscale-first and then applies a broad mean-color sanity check. That still allows some false positives where:
- the structure of the image remains very similar in grayscale
- the average color is still close enough globally
- but the specific pixels that carry the condition's color signal have become much less saturated

The hero deployment example in #865 is one such case: the undeployed and already-deployed states both produce about the same confidence, even though one has clearly lost its original color information.

## What changed
- keep the existing grayscale template matching behavior
- keep the existing mean-color validation
- add a second color validation based on saturation drop:
  - convert the candidate and condition images to HSV
  - build a mask from pixels that are sufficiently colorful in the saved condition image
  - ignore templates that barely contain any colorful pixels
  - measure the average saturation loss only inside that colorful mask
  - reject the candidate when that saturation loss exceeds the threshold

This keeps the new check focused on pixels that are actually supposed to carry color information, instead of turning saturation into a blanket rule across the whole candidate.

## Validation
- cherry-picked cleanly onto `upstream/master`
- built `:smartautoclicker:assembleFDroidDebug` successfully on the upstream-compatible branch
- previously validated in downstream real-world use against the false-positive case from #865, with no false negatives observed in limited manual testing