### PR TITLE
Derive runtime package names dynamically

### DIFF
--- a/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/data/AppComponentsManager.kt
+++ b/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/data/AppComponentsManager.kt
@@ -22,6 +22,7 @@ import javax.inject.Singleton
 
 
 interface AppComponentsProvider {
+    val currentAppId: String
     val originalAppId: String
 
     val klickrServiceComponentName: ComponentName
@@ -32,6 +33,10 @@ interface AppComponentsProvider {
 
 @Singleton
 class AppComponentsManager @Inject constructor() : AppComponentsProvider {
+
+    private lateinit var _currentAppId: String
+    override val currentAppId: String
+        get() = _currentAppId
 
     private lateinit var _originalAppId: String
     override val originalAppId: String
@@ -47,9 +52,13 @@ class AppComponentsManager @Inject constructor() : AppComponentsProvider {
 
     override val tutorialActivityComponentName: ComponentName
         get() = ComponentName(
-            "com.buzbuz.smartautoclicker",
+            currentAppId,
             "com.buzbuz.smartautoclicker.feature.tutorial.ui.TutorialActivity",
         )
+
+    fun registerCurrentAppId(appId: String) {
+        _currentAppId = appId
+    }
 
     fun registerOriginalAppId(appId: String) {
         _originalAppId = appId

--- a/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/data/SystemIntents.kt
+++ b/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/data/SystemIntents.kt
@@ -35,8 +35,8 @@ fun getOpenWebBrowserPickerIntent(uri: Uri): Intent =
     }
 
 @RequiresApi(Build.VERSION_CODES.O)
-fun getNotificationSettingsIntent(): Intent =
+fun getNotificationSettingsIntent(appPackageName: String): Intent =
     Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        putExtra(Settings.EXTRA_APP_PACKAGE, "com.buzbuz.smartautoclicker")
+        putExtra(Settings.EXTRA_APP_PACKAGE, appPackageName)
     }

--- a/core/common/permissions/src/main/java/com/buzbuz/smartautoclicker/core/common/permissions/model/Permission.kt
+++ b/core/common/permissions/src/main/java/com/buzbuz/smartautoclicker/core/common/permissions/model/Permission.kt
@@ -65,7 +65,7 @@ sealed class Permission(internal val isOptional: Boolean) {
         /** The Android permission string value. */
         protected abstract val permissionString: String
 
-        protected open val fallbackSettingsIntent: Intent? = null
+        protected open fun getFallbackSettingsIntent(context: Context): Intent? = null
 
         internal fun initResultLauncher(fragment: Fragment, onResult: (isGranted: Boolean) -> Unit) {
             permissionLauncher = fragment
@@ -88,7 +88,7 @@ sealed class Permission(internal val isOptional: Boolean) {
                 } ?: false
             }
 
-            fallbackSettingsIntent?.let { intent ->
+            getFallbackSettingsIntent(context)?.let { intent ->
                 try {
                     context.startActivity(intent)
                     return true

--- a/core/common/permissions/src/main/java/com/buzbuz/smartautoclicker/core/common/permissions/model/PermissionPostNotification.kt
+++ b/core/common/permissions/src/main/java/com/buzbuz/smartautoclicker/core/common/permissions/model/PermissionPostNotification.kt
@@ -36,8 +36,8 @@ data class PermissionPostNotification(
     override val permissionString: String
         get() = Manifest.permission.POST_NOTIFICATIONS
 
-    override val fallbackSettingsIntent: Intent
-        get() = getNotificationSettingsIntent()
+    override fun getFallbackSettingsIntent(context: Context): Intent =
+        getNotificationSettingsIntent(context.packageName)
 
     override fun isGranted(context: Context): Boolean =
         context.getSystemService(NotificationManager::class.java).areNotificationsEnabled()

--- a/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/ServiceNotificationController.kt
+++ b/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/ServiceNotificationController.kt
@@ -47,7 +47,7 @@ class ServiceNotificationController(
     private val notificationManager: NotificationManagerCompat =
         NotificationManagerCompat.from(context)
     private val notificationActionReceiver: NotificationActionsReceiver =
-        NotificationActionsReceiver(listener::notifyAction)
+        NotificationActionsReceiver(appComponentsProvider, listener::notifyAction)
     private val nightModeReceiver: NightModeReceiver =
         NightModeReceiver(::updateNotification)
 

--- a/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/model/ServiceNotificationAction.kt
+++ b/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/model/ServiceNotificationAction.kt
@@ -72,22 +72,22 @@ internal sealed class NotificationActionPendingIntent {
     data class Activity(val componentName: ComponentName) : NotificationActionPendingIntent()
 }
 
-internal fun getAllActionsBroadcastIntentFilter(): IntentFilter =
+internal fun getAllActionsBroadcastIntentFilter(appPackageName: String): IntentFilter =
     IntentFilter().apply {
-        addAction(ServiceNotificationAction.Play.getBroadcastAction())
-        addAction(ServiceNotificationAction.Pause.getBroadcastAction())
-        addAction(ServiceNotificationAction.Show.getBroadcastAction())
-        addAction(ServiceNotificationAction.Hide.getBroadcastAction())
-        addAction(ServiceNotificationAction.Stop.getBroadcastAction())
+        addAction(ServiceNotificationAction.Play.getBroadcastAction(appPackageName))
+        addAction(ServiceNotificationAction.Pause.getBroadcastAction(appPackageName))
+        addAction(ServiceNotificationAction.Show.getBroadcastAction(appPackageName))
+        addAction(ServiceNotificationAction.Hide.getBroadcastAction(appPackageName))
+        addAction(ServiceNotificationAction.Stop.getBroadcastAction(appPackageName))
     }
 
-internal fun Intent.toServiceNotificationAction(): ServiceNotificationAction? =
+internal fun Intent.toServiceNotificationAction(appPackageName: String): ServiceNotificationAction? =
     when (action) {
-        ServiceNotificationAction.Play.getBroadcastAction() -> ServiceNotificationAction.Play
-        ServiceNotificationAction.Pause.getBroadcastAction() -> ServiceNotificationAction.Pause
-        ServiceNotificationAction.Show.getBroadcastAction() -> ServiceNotificationAction.Show
-        ServiceNotificationAction.Hide.getBroadcastAction() -> ServiceNotificationAction.Hide
-        ServiceNotificationAction.Stop.getBroadcastAction() -> ServiceNotificationAction.Stop
+        ServiceNotificationAction.Play.getBroadcastAction(appPackageName) -> ServiceNotificationAction.Play
+        ServiceNotificationAction.Pause.getBroadcastAction(appPackageName) -> ServiceNotificationAction.Pause
+        ServiceNotificationAction.Show.getBroadcastAction(appPackageName) -> ServiceNotificationAction.Show
+        ServiceNotificationAction.Hide.getBroadcastAction(appPackageName) -> ServiceNotificationAction.Hide
+        ServiceNotificationAction.Stop.getBroadcastAction(appPackageName) -> ServiceNotificationAction.Stop
         else -> null
     }
 
@@ -108,20 +108,20 @@ internal fun ServiceNotificationAction.getPendingIntent(context: Context, appCom
 
 private fun ServiceNotificationAction.getIntent(appComponentsProvider: AppComponentsProvider): NotificationActionPendingIntent =
     when (this) {
-        ServiceNotificationAction.Play -> NotificationActionPendingIntent.Broadcast(getBroadcastAction())
-        ServiceNotificationAction.Pause -> NotificationActionPendingIntent.Broadcast(getBroadcastAction())
-        ServiceNotificationAction.Show -> NotificationActionPendingIntent.Broadcast(getBroadcastAction())
-        ServiceNotificationAction.Hide -> NotificationActionPendingIntent.Broadcast(getBroadcastAction())
-        ServiceNotificationAction.Stop -> NotificationActionPendingIntent.Broadcast(getBroadcastAction())
+        ServiceNotificationAction.Play -> NotificationActionPendingIntent.Broadcast(getBroadcastAction(appComponentsProvider.currentAppId))
+        ServiceNotificationAction.Pause -> NotificationActionPendingIntent.Broadcast(getBroadcastAction(appComponentsProvider.currentAppId))
+        ServiceNotificationAction.Show -> NotificationActionPendingIntent.Broadcast(getBroadcastAction(appComponentsProvider.currentAppId))
+        ServiceNotificationAction.Hide -> NotificationActionPendingIntent.Broadcast(getBroadcastAction(appComponentsProvider.currentAppId))
+        ServiceNotificationAction.Stop -> NotificationActionPendingIntent.Broadcast(getBroadcastAction(appComponentsProvider.currentAppId))
         ServiceNotificationAction.Config -> NotificationActionPendingIntent.Activity(appComponentsProvider.scenarioActivityComponentName)
     }
 
-private fun ServiceNotificationAction.getBroadcastAction(): String =
+private fun ServiceNotificationAction.getBroadcastAction(appPackageName: String): String =
     when (this) {
-        ServiceNotificationAction.Play -> "com.buzbuz.smartautoclicker.PLAY"
-        ServiceNotificationAction.Pause -> "com.buzbuz.smartautoclicker.PAUSE"
-        ServiceNotificationAction.Show -> "com.buzbuz.smartautoclicker.SHOW"
-        ServiceNotificationAction.Hide -> "com.buzbuz.smartautoclicker.HIDE"
-        ServiceNotificationAction.Stop -> "com.buzbuz.smartautoclicker.STOP"
+        ServiceNotificationAction.Play -> "$appPackageName.PLAY"
+        ServiceNotificationAction.Pause -> "$appPackageName.PAUSE"
+        ServiceNotificationAction.Show -> "$appPackageName.SHOW"
+        ServiceNotificationAction.Hide -> "$appPackageName.HIDE"
+        ServiceNotificationAction.Stop -> "$appPackageName.STOP"
         ServiceNotificationAction.Config -> throw IllegalArgumentException("This action doesn't use broadcasts")
     }

--- a/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/receivers/NotificationActionsReceiver.kt
+++ b/feature/notifications/src/main/java/com/buzbuz/smartautoclicker/feature/notifications/receivers/NotificationActionsReceiver.kt
@@ -21,17 +21,19 @@ import android.content.Intent
 import android.util.Log
 
 import com.buzbuz.smartautoclicker.core.base.SafeBroadcastReceiver
+import com.buzbuz.smartautoclicker.core.base.data.AppComponentsProvider
 import com.buzbuz.smartautoclicker.feature.notifications.model.ServiceNotificationAction
 import com.buzbuz.smartautoclicker.feature.notifications.model.getAllActionsBroadcastIntentFilter
 import com.buzbuz.smartautoclicker.feature.notifications.model.toServiceNotificationAction
 
 
 internal class NotificationActionsReceiver(
+    appComponentsProvider: AppComponentsProvider,
     private val onReceived: (ServiceNotificationAction) -> Unit,
-): SafeBroadcastReceiver(getAllActionsBroadcastIntentFilter()) {
+): SafeBroadcastReceiver(getAllActionsBroadcastIntentFilter(appComponentsProvider.currentAppId)) {
 
     override fun onReceive(context: Context, intent: Intent) {
-        intent.toServiceNotificationAction()?.let { action ->
+        intent.toServiceNotificationAction(context.packageName)?.let { action ->
             Log.i(TAG, "Notification action received: ${intent.action}")
             onReceived(action)
         }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/notification/NotificationDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/action/notification/NotificationDialog.kt
@@ -214,7 +214,7 @@ class NotificationDialog(
 
         overlayManager.navigateTo(
             context = context,
-            newOverlay = newNotificationSettingsStarterOverlay(),
+            newOverlay = newNotificationSettingsStarterOverlay(context),
             hideCurrent = true,
         )
     }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/starters/StartersOverlays.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/starters/StartersOverlays.kt
@@ -41,6 +41,6 @@ internal fun newNotificationPermissionStarterOverlay(context: Context) = Activit
 )
 
 @RequiresApi(Build.VERSION_CODES.O)
-internal fun newNotificationSettingsStarterOverlay() = ActivityStarterOverlayMenu(
-    intent = getNotificationSettingsIntent(),
+internal fun newNotificationSettingsStarterOverlay(context: Context) = ActivityStarterOverlayMenu(
+    intent = getNotificationSettingsIntent(context.packageName),
 )

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/application/SmartAutoClickerApplication.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/application/SmartAutoClickerApplication.kt
@@ -33,6 +33,7 @@ class SmartAutoClickerApplication : Application() {
 
         val componentConfig = ComponentConfig
         appComponentsManager.apply {
+            registerCurrentAppId(packageName)
             registerOriginalAppId(componentConfig.ORIGINAL_APP_ID)
             registerSmartAutoClickerService(componentConfig.smartAutoClickerService)
             registerScenarioActivity(componentConfig.scenarioActivity)


### PR DESCRIPTION
## Summary
- derive package-sensitive runtime targets from the installed app package instead of hardcoding `com.buzbuz.smartautoclicker`
- fix tutorial launch, notification settings routing, and notification action broadcast names for builds where the package name differs from vanilla
- keep the change narrow and behavior-preserving for normal builds while improving support for obscured or otherwise renamed package variants

## Why
This is meant to solve a possible issue with the obscured version and any other package name modifications.

In my personal fork with a modified package name, hardcoded app package usage caused crashes. The most noticeable case was opening the tutorial, which led to an instant crash because the app tried to start a component under the vanilla package name.

More generally, avoiding hardcoded app package names in these runtime paths is good hygiene and makes the app more robust to package renaming.

Fixes #925

## Testing
- hosted fork debug APK workflow passed for the equivalent patch on my fork
- the resulting patched debug APK installed successfully on device after replacing an older debug install
- this exact upstream branch/version has not been manually tested by me on device yet
