### PR TITLE
Overlay passthrough during runtime live debug panel

### DIFF
--- a/core/common/actions/build.gradle.kts
+++ b/core/common/actions/build.gradle.kts
@@ -16,6 +16,7 @@
  */
 plugins {
     alias(libs.plugins.buzbuz.androidLibrary)
+    alias(libs.plugins.buzbuz.androidUnitTest)
     alias(libs.plugins.buzbuz.flavour)
     alias(libs.plugins.buzbuz.hilt)
 }
@@ -31,4 +32,6 @@ dependencies {
     implementation(project(":core:common:base"))
     implementation(project(":core:common:permissions"))
     implementation(project(":core:common:ui"))
+
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/common/actions/src/main/java/com/buzbuz/smartautoclicker/core/common/actions/AndroidActionExecutor.kt
+++ b/core/common/actions/src/main/java/com/buzbuz/smartautoclicker/core/common/actions/AndroidActionExecutor.kt
@@ -22,7 +22,15 @@ import android.content.Intent
 import com.buzbuz.smartautoclicker.core.base.Dumpable
 import com.buzbuz.smartautoclicker.core.common.actions.model.ActionNotificationRequest
 
+interface GestureDispatchListener {
+    fun onGestureWillDispatch()
+    fun onGestureDidDispatch()
+}
+
 interface AndroidActionExecutor: Dumpable {
+
+    /** Sets the listener to be notified when gestures are about to be dispatched or completed. */
+    fun setGestureDispatchListener(listener: GestureDispatchListener?)
 
     /**
      * Initialize the executor.

--- a/core/common/actions/src/main/java/com/buzbuz/smartautoclicker/core/common/actions/AndroidActionExecutorImpl.kt
+++ b/core/common/actions/src/main/java/com/buzbuz/smartautoclicker/core/common/actions/AndroidActionExecutorImpl.kt
@@ -44,6 +44,7 @@ internal class AndroidActionExecutorImpl @Inject constructor(
 
     /** Keep the service in a week reference to avoid potential leak. */
     private var accessibilityServiceRef: WeakReference<AccessibilityService>? = null
+    private var gestureDispatchListener: GestureDispatchListener? = null
     private val accessibilityService: AccessibilityService?
         get() {
             val ref = accessibilityServiceRef ?: let {
@@ -55,6 +56,10 @@ internal class AndroidActionExecutorImpl @Inject constructor(
                 null
             }
         }
+
+    override fun setGestureDispatchListener(listener: GestureDispatchListener?) {
+        gestureDispatchListener = listener
+    }
 
     override fun init(service: AccessibilityService) {
         accessibilityServiceRef = WeakReference(service)
@@ -69,14 +74,20 @@ internal class AndroidActionExecutorImpl @Inject constructor(
     override fun clear() {
         resetState()
         accessibilityServiceRef = null
+        gestureDispatchListener = null
     }
 
     override suspend fun dispatchGesture(gestureDescription: GestureDescription) {
         val service = accessibilityService ?: return
 
-        if (!gestureExecutor.dispatchGesture(service, gestureDescription)) {
-            Log.w(TAG, "System did not execute the gesture properly, delaying processing to avoid spamming slow system")
-            delay(500)
+        gestureDispatchListener?.onGestureWillDispatch()
+        try {
+            if (!gestureExecutor.dispatchGesture(service, gestureDescription)) {
+                Log.w(TAG, "System did not execute the gesture properly, delaying processing to avoid spamming slow system")
+                delay(500)
+            }
+        } finally {
+            gestureDispatchListener?.onGestureDidDispatch()
         }
     }
 

--- a/core/common/actions/src/test/java/com/buzbuz/smartautoclicker/core/common/actions/AndroidActionExecutorImplTests.kt
+++ b/core/common/actions/src/test/java/com/buzbuz/smartautoclicker/core/common/actions/AndroidActionExecutorImplTests.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.core.common.actions
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.GestureDescription
+import android.os.Build
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import com.buzbuz.smartautoclicker.core.common.actions.gesture.GestureExecutor
+import com.buzbuz.smartautoclicker.core.common.actions.notification.NotificationRequestExecutor
+import com.buzbuz.smartautoclicker.core.common.actions.text.TextExecutor
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class AndroidActionExecutorImplTests {
+
+    @Mock private lateinit var mockGestureExecutor: GestureExecutor
+    @Mock private lateinit var mockNotificationRequestExecutor: NotificationRequestExecutor
+    @Mock private lateinit var mockTextExecutor: TextExecutor
+    @Mock private lateinit var mockAccessibilityService: AccessibilityService
+    @Mock private lateinit var mockGestureDescription: GestureDescription
+    @Mock private lateinit var mockListener: GestureDispatchListener
+
+    private lateinit var actionExecutor: AndroidActionExecutorImpl
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        actionExecutor = AndroidActionExecutorImpl(
+            mockGestureExecutor,
+            mockNotificationRequestExecutor,
+            mockTextExecutor,
+        )
+    }
+
+    @Test
+    fun dispatchGesture_notifiesListener() = runTest {
+        actionExecutor.init(mockAccessibilityService)
+        actionExecutor.setGestureDispatchListener(mockListener)
+
+        `when`(mockGestureExecutor.dispatchGesture(mockAccessibilityService, mockGestureDescription)).thenReturn(true)
+
+        actionExecutor.dispatchGesture(mockGestureDescription)
+
+        inOrder(mockListener, mockGestureExecutor).apply {
+            verify(mockListener).onGestureWillDispatch()
+            verify(mockGestureExecutor).dispatchGesture(mockAccessibilityService, mockGestureDescription)
+            verify(mockListener).onGestureDidDispatch()
+        }
+    }
+
+    @Test
+    fun dispatchGesture_notifiesListenerOnFailure() = runTest {
+        actionExecutor.init(mockAccessibilityService)
+        actionExecutor.setGestureDispatchListener(mockListener)
+
+        `when`(mockGestureExecutor.dispatchGesture(mockAccessibilityService, mockGestureDescription)).thenAnswer {
+            throw RuntimeException("Test error")
+        }
+
+        try {
+            actionExecutor.dispatchGesture(mockGestureDescription)
+        } catch (e: Exception) {
+            // expected
+        }
+
+        inOrder(mockListener, mockGestureExecutor).apply {
+            verify(mockListener).onGestureWillDispatch()
+            verify(mockGestureExecutor).dispatchGesture(mockAccessibilityService, mockGestureDescription)
+            verify(mockListener).onGestureDidDispatch()
+        }
+    }
+}

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/base/Overlay.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/base/Overlay.kt
@@ -99,4 +99,6 @@ abstract class Overlay : LifecycleOwner, ViewModelStoreOwner, HasDefaultViewMode
     internal abstract fun handleKeyEvent(keyEvent: KeyEvent): Boolean
     /** Change the orientation of the overlay. */
     internal abstract fun changeOrientation()
+    /** Enable/disable touchability of the overlay window(s). */
+    internal open fun setWindowTouchable(touchable: Boolean) = Unit
 }

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/manager/OverlayManager.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/manager/OverlayManager.kt
@@ -221,6 +221,15 @@ class OverlayManager @Inject internal constructor(
     fun isOverlayStackVisible(): Boolean =
         getBackStackTop()?.lifecycle?.currentState?.isAtLeast(Lifecycle.State.STARTED) ?: false
 
+    /** Enable/disable touchability of all overlay windows in the back stack. */
+    fun setOverlaysTouchable(touchable: Boolean) {
+        Log.d(TAG, "setOverlaysTouchable: $touchable")
+        topOverlay?.setWindowTouchable(touchable)
+        overlayBackStack.forEach { overlay ->
+            overlay.setWindowTouchable(touchable)
+        }
+    }
+
     /**
      * Set an overlay as being shown above all overlays in the backstack.
      * It will not be added to the backstack, and can be seen as "an overlay for overlays".

--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
@@ -28,6 +28,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.view.WindowManager
 import android.widget.ImageButton
 
@@ -145,6 +146,86 @@ abstract class OverlayMenu(
     protected var screenOverlayView: View? = null
     /** The layout parameters of the overlay view. */
     private lateinit var overlayLayoutParams: WindowManager.LayoutParams
+    private var requestedWindowTouchable: Boolean = true
+
+    private var internalInsetsListenerProxy: Any? = null
+
+    private fun setupInternalInsetsListener() {
+        if (internalInsetsListenerProxy != null) return
+        try {
+            val listenerClass = Class.forName("android.view.ViewTreeObserver\$OnComputeInternalInsetsListener")
+            val touchableRegionField = Class.forName("android.view.ViewTreeObserver\$InternalInsetsInfo").getField("touchableRegion")
+            val setTouchableInsetsMethod = Class.forName("android.view.ViewTreeObserver\$InternalInsetsInfo").getMethod("setTouchableInsets", java.lang.Integer.TYPE)
+
+            val proxy = java.lang.reflect.Proxy.newProxyInstance(
+                listenerClass.classLoader,
+                arrayOf(listenerClass)
+            ) { _, method, args ->
+                if (method.name == "onComputeInternalInsets") {
+                    val insetsInfo = args[0]
+                    val region = touchableRegionField.get(insetsInfo) as android.graphics.Region
+                    region.setEmpty()
+
+                    getTouchableViews().forEach { view ->
+                        if (view.visibility == View.VISIBLE && view.isAttachedToWindow) {
+                            val rect = android.graphics.Rect()
+                            view.getDrawingRect(rect)
+                            try {
+                                menuLayout.offsetDescendantRectToMyCoords(view, rect)
+                                region.union(rect)
+                            } catch (e: IllegalArgumentException) {
+                                // Descendant view is not a child of menuLayout
+                            }
+                        }
+                    }
+
+                    setTouchableInsetsMethod.invoke(insetsInfo, TOUCHABLE_INSETS_REGION)
+                }
+                null
+            }
+
+            val addMethod = ViewTreeObserver::class.java.getMethod("addOnComputeInternalInsetsListener", listenerClass)
+            addMethod.invoke(menuLayout.viewTreeObserver, proxy)
+            internalInsetsListenerProxy = proxy
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to setup OnComputeInternalInsetsListener via reflection", e)
+        }
+    }
+
+    private fun removeInternalInsetsListener() {
+        val proxy = internalInsetsListenerProxy ?: return
+        try {
+            val listenerClass = Class.forName("android.view.ViewTreeObserver\$OnComputeInternalInsetsListener")
+            val removeMethod = ViewTreeObserver::class.java.getMethod("removeOnComputeInternalInsetsListener", listenerClass)
+            removeMethod.invoke(menuLayout.viewTreeObserver, proxy)
+            internalInsetsListenerProxy = null
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to remove OnComputeInternalInsetsListener via reflection", e)
+        }
+    }
+
+    private fun updateInternalInsetsListener() {
+        if (!this::menuLayout.isInitialized || !menuLayout.isAttachedToWindow) return
+
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED) && shouldUseTouchableInsets()) {
+            setupInternalInsetsListener()
+            menuLayout.requestLayout()
+        } else {
+            removeInternalInsetsListener()
+        }
+    }
+
+    protected open fun getTouchableViews(): List<View> {
+        return listOf(buttonsContainer)
+    }
+
+    protected open fun shouldUseTouchableInsets(): Boolean = false
+
+    protected open fun shouldUseGestureDispatchWindowTouchability(): Boolean = false
+
+    /** Tells if the overlay menu should be animated when shown/hidden. True by default. */
+    protected open fun shouldAnimateMenu(): Boolean = true
 
     private val onLockedPositionChangedListener: (Point?) -> Unit = ::onLockedPositionChanged
 
@@ -199,6 +280,17 @@ abstract class OverlayMenu(
         menuBackground = menuLayout.findViewById(R.id.menu_background)
         buttonsContainer = menuLayout.findViewById(R.id.menu_items)
         setupButtons(buttonsContainer)
+
+        // Add the attach listener to set up the insets listener when attached to the window
+        menuLayout.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                updateInternalInsetsListener()
+            }
+
+            override fun onViewDetachedFromWindow(v: View) {
+                removeInternalInsetsListener()
+            }
+        })
 
         // Setup the touch event handler for the move button
         moveTouchEventHandler = OverlayMenuMoveTouchEventHandler(::updateMenuPosition)
@@ -263,6 +355,9 @@ abstract class OverlayMenu(
         super.start()
         loadMenuPosition(displayConfigManager.displayConfig.orientation)
 
+        requestedWindowTouchable = true
+        refreshTouchHandling()
+
         // Start the show animation for the menu
         Log.d(TAG, "Start show overlay ${hashCode()} animation...")
 
@@ -270,13 +365,20 @@ abstract class OverlayMenu(
         menuLayout.visibility = View.VISIBLE
         menuBackground.visibility = View.VISIBLE
         animatedOverlayView?.visibility = View.VISIBLE
-        animations.startShowAnimation(menuBackground, animatedOverlayView) {
+
+        val onAnimationEnded = {
             Log.d(TAG, "Show overlay ${hashCode()} animation ended")
 
             if (resumeOnceShown) {
                 resumeOnceShown = false
                 resume()
             }
+        }
+
+        if (shouldAnimateMenu()) {
+            animations.startShowAnimation(menuBackground, animatedOverlayView, onAnimationEnded)
+        } else {
+            onAnimationEnded()
         }
     }
 
@@ -302,10 +404,7 @@ abstract class OverlayMenu(
 
         saveMenuPosition(displayConfigManager.displayConfig.orientation)
 
-        // Start the hide animation for the menu
-        Log.d(TAG, "Start overlay ${hashCode()} hide animation...")
-        val animatedOverlayView = if (animateOverlayView()) screenOverlayView else null
-        animations.startHideAnimation(menuBackground, animatedOverlayView) {
+        val onAnimationEnded = {
             Log.d(TAG, "Hide overlay ${hashCode()} animation ended")
 
             menuLayout.visibility = View.GONE
@@ -313,11 +412,21 @@ abstract class OverlayMenu(
             screenOverlayView?.visibility = View.GONE
 
             super.stop()
+            refreshTouchHandling()
 
             if (destroyOnceHidden) {
                 destroyOnceHidden = false
                 destroy()
             }
+        }
+
+        // Start the hide animation for the menu
+        Log.d(TAG, "Start overlay ${hashCode()} hide animation...")
+        val animatedOverlayView = if (animateOverlayView()) screenOverlayView else null
+        if (shouldAnimateMenu()) {
+            animations.startHideAnimation(menuBackground, animatedOverlayView, onAnimationEnded)
+        } else {
+            onAnimationEnded()
         }
     }
 
@@ -605,7 +714,34 @@ abstract class OverlayMenu(
             positionDataSource.dump(writer, contentPrefix)
         }
     }
+    protected fun refreshTouchHandling() {
+        updateInternalInsetsListener()
+        setMenuWindowTouchable(requestedWindowTouchable || !shouldUseGestureDispatchWindowTouchability())
+    }
+
+    protected fun setMenuWindowTouchable(touchable: Boolean) {
+        if (!this::menuLayout.isInitialized) return
+
+        val updatedFlags = if (touchable) {
+            menuLayoutParams.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE.inv()
+        } else {
+            menuLayoutParams.flags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+        }
+
+        if (menuLayoutParams.flags == updatedFlags) return
+
+        menuLayoutParams.flags = updatedFlags
+        if (menuLayout.isAttachedToWindow) {
+            windowManager.safeUpdateViewLayout(menuLayout, menuLayoutParams)
+        }
+    }
+
+    override fun setWindowTouchable(touchable: Boolean) {
+        requestedWindowTouchable = touchable
+        refreshTouchHandling()
+    }
 }
 
 /** Tag for logs */
 private const val TAG = "OverlayMenu"
+private const val TOUCHABLE_INSETS_REGION = 3

--- a/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/manager/OverlayManagerTests.kt
+++ b/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/manager/OverlayManagerTests.kt
@@ -234,4 +234,22 @@ class OverlayManagerTests {
         }
         Mockito.verifyNoMoreInteractions(mockOverlay1, mockOverlay2)
     }
+
+    @Test
+    fun setOverlaysTouchable_propagatesToBackStack() {
+        overlayManager.navigateTo(mockContext, mockOverlay1)
+        overlayManager.navigateTo(mockContext, mockOverlay2)
+        Mockito.clearInvocations(mockOverlay1, mockOverlay2)
+
+        overlayManager.setOverlaysTouchable(false)
+        overlayManager.setOverlaysTouchable(true)
+
+        Mockito.inOrder(mockOverlay1, mockOverlay2).apply {
+            verify(mockOverlay1).setWindowTouchable(false)
+            verify(mockOverlay2).setWindowTouchable(false)
+            verify(mockOverlay1).setWindowTouchable(true)
+            verify(mockOverlay2).setWindowTouchable(true)
+        }
+        Mockito.verifyNoMoreInteractions(mockOverlay1, mockOverlay2)
+    }
 }

--- a/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenuTests.kt
+++ b/core/common/overlays/src/test/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenuTests.kt
@@ -79,14 +79,23 @@ class OverlayMenuTests {
      * @param impl the mock called for each abstract method calls.
      */
     class OverlayMenuTestImpl(private val impl: OverlayMenuControllerImpl) : OverlayMenu() {
+        var useTouchableInsets: Boolean = false
+        var useGestureDispatchWindowTouchability: Boolean = false
+
         override fun onCreateMenu(layoutInflater: LayoutInflater): ViewGroup = impl.onCreateMenu(layoutInflater)
         override fun onCreateOverlayView(): View? = impl.onCreateOverlayView()
+        override fun shouldUseTouchableInsets(): Boolean = useTouchableInsets
+        override fun shouldUseGestureDispatchWindowTouchability(): Boolean = useGestureDispatchWindowTouchability
+        override fun shouldAnimateMenu(): Boolean = false
         override fun onMenuItemClicked(viewId: Int) {
             impl.onMenuItemClicked(viewId)
         }
         override fun onStart() {
             super.onStart()
             impl.onShow()
+        }
+        fun publicSetWindowTouchable(touchable: Boolean) {
+            setWindowTouchable(touchable)
         }
         fun publicSetMenuItemViewEnabled(view: View, enabled: Boolean, clickable: Boolean = false) {
             setMenuItemViewEnabled(view, enabled, clickable)
@@ -371,5 +380,76 @@ class OverlayMenuTests {
 
         verify(item).isEnabled = true
         verify(item).alpha = 1f
+    }
+
+    @Test
+    fun stopStart_keepsOverlayViewTouchableFlags() {
+        overlayMenuController = OverlayMenuTestImpl(overlayMenuControllerImpl)
+        val menuView = mock(ViewGroup::class.java)
+        val overlayView = mock(View::class.java)
+        mockViewsFromImpl(menuView, overlayView)
+
+        overlayMenuController.create(mockContext)
+        overlayMenuController.start()
+
+        val addedViews = captureWindowManagerAddedViews(mockWindowManager)
+        val initialOverlayFlags = addedViews.first.params.flags
+
+        overlayMenuController.stop()
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        overlayMenuController.start()
+
+        assertEquals(initialOverlayFlags, addedViews.first.params.flags)
+    }
+
+    @Test
+    fun setWindowTouchable_updatesAndRestoresMenuFlags() {
+        overlayMenuController = OverlayMenuTestImpl(overlayMenuControllerImpl).apply {
+            useTouchableInsets = true
+            useGestureDispatchWindowTouchability = true
+        }
+        mockViewsFromImpl()
+
+        overlayMenuController.create(mockContext)
+        overlayMenuController.start()
+
+        val addedView = captureWindowManagerAddedMenuView(mockWindowManager)
+        val initialMenuFlags = addedView.params.flags
+
+        overlayMenuController.publicSetWindowTouchable(false)
+        assertEquals(
+            initialMenuFlags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+            addedView.params.flags,
+        )
+
+        overlayMenuController.publicSetWindowTouchable(true)
+        assertEquals(initialMenuFlags, addedView.params.flags)
+    }
+
+    @Test
+    fun setWindowTouchable_restoresTouchStateAfterRestart() {
+        overlayMenuController = OverlayMenuTestImpl(overlayMenuControllerImpl).apply {
+            useTouchableInsets = true
+            useGestureDispatchWindowTouchability = true
+        }
+        mockViewsFromImpl()
+
+        overlayMenuController.create(mockContext)
+        overlayMenuController.start()
+
+        val addedView = captureWindowManagerAddedMenuView(mockWindowManager)
+        val initialMenuFlags = addedView.params.flags
+
+        overlayMenuController.publicSetWindowTouchable(false)
+        assertEquals(
+            initialMenuFlags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+            addedView.params.flags,
+        )
+
+        overlayMenuController.stop()
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        overlayMenuController.start()
+
+        assertEquals(initialMenuFlags, addedView.params.flags)
     }
 }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/mainmenu/MainMenu.kt
@@ -84,6 +84,8 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
 
     /** The coroutine job for the observable used in debug mode. Null when not in debug mode. */
     private var debugObservableJob: Job? = null
+    private var isScenarioRunning: Boolean = false
+    private var isDebugPanelVisible: Boolean = false
 
     /**
      * Tells if this service has handled onKeyEvent with ACTION_DOWN for a key in order to return
@@ -132,6 +134,10 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
         }
     }
 
+    override fun shouldUseTouchableInsets(): Boolean = shouldUseRuntimeDebugPassthrough()
+
+    override fun shouldUseGestureDispatchWindowTouchability(): Boolean = shouldUseRuntimeDebugPassthrough()
+
     override fun onStart() {
         super.onStart()
 
@@ -142,6 +148,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
 
         // Start loading advertisement if needed
         viewModel.loadAdIfNeeded(context)
+        updateRuntimeDebugTouchHandling()
     }
 
     override fun onStop() {
@@ -231,6 +238,8 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
     /** Refresh the menu layout according to the detection state. */
     private fun updateDetectionState(newState: UiState) {
         val currentState = viewBinding.btnPlay.tag
+        isScenarioRunning = newState == UiState.Detecting
+        updateRuntimeDebugTouchHandling()
         if (currentState == newState) return
 
         viewBinding.btnPlay.tag = newState
@@ -280,6 +289,7 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
      * @param isVisible true when the debug view should be shown, false to hide it.
      */
     private fun updateDebugOverlayViewVisibility(isVisible: Boolean) {
+        isDebugPanelVisible = isVisible
         if (isVisible && debugObservableJob == null) {
             viewBinding.layoutDebug.visibility = View.VISIBLE
             debugObservableJob = observeDebugValues()
@@ -291,6 +301,15 @@ class MainMenu(private val onStopClicked: () -> Unit) : OverlayMenu() {
             updateLiveDebugUiState(null)
             viewBinding.layoutDebug.visibility = View.GONE
         }
+
+        updateRuntimeDebugTouchHandling()
+    }
+
+    private fun shouldUseRuntimeDebugPassthrough(): Boolean =
+        isScenarioRunning && isDebugPanelVisible
+
+    private fun updateRuntimeDebugTouchHandling() {
+        refreshTouchHandling()
     }
 
     /**

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/SmartAutoClickerService.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/SmartAutoClickerService.kt
@@ -30,6 +30,7 @@ import com.buzbuz.smartautoclicker.core.base.extensions.startForegroundMediaProj
 import com.buzbuz.smartautoclicker.core.base.notifications.NotificationIds
 import com.buzbuz.smartautoclicker.core.bitmaps.BitmapRepository
 import com.buzbuz.smartautoclicker.core.common.actions.AndroidActionExecutor
+import com.buzbuz.smartautoclicker.core.common.actions.GestureDispatchListener
 import com.buzbuz.smartautoclicker.core.common.overlays.manager.OverlayManager
 import com.buzbuz.smartautoclicker.core.common.quality.domain.QualityMetricsMonitor
 import com.buzbuz.smartautoclicker.core.common.quality.domain.QualityRepository
@@ -94,6 +95,15 @@ class SmartAutoClickerService : AccessibilityService() {
 
         qualityMetricsMonitor.onServiceConnected()
         actionExecutor.init(this)
+        actionExecutor.setGestureDispatchListener(object : GestureDispatchListener {
+            override fun onGestureWillDispatch() {
+                overlayManager.setOverlaysTouchable(false)
+            }
+
+            override fun onGestureDidDispatch() {
+                overlayManager.setOverlaysTouchable(true)
+            }
+        })
 
         tileRepository.setTileActionHandler(
             object : QSTileActionHandler {


### PR DESCRIPTION
### Description

This Pull Request narrows overlay touch passthrough to the specific runtime case where it is useful: the smart MainMenu while scenario detection is running and the live debug panel is visible.

### What Changed

- **Overlay Menu Passthrough Opt-In**: Moves the passthrough / internal insets shaping in `OverlayMenu` from shared default behavior to an explicit opt-in path (`shouldUseTouchableInsets()` and `shouldUseGestureDispatchWindowTouchability()`).
- **Targeted MainMenu passthrough**: MainMenu opts in only when scenario detection is running and the live debug panel is visible. This allows the debug side panel to remain visible and informational without blocking user touch interaction with the underlying app.
- **Untouchable Overlays during Gesture Dispatch**: Introduced `GestureDispatchListener` in `AndroidActionExecutor`. Wired this in `SmartAutoClickerService` to temporarily toggle all overlay windows to untouchable (`FLAG_NOT_TOUCHABLE`) when a gesture is about to be dispatched, and restore their touchability immediately after. This prevents overlays from intercepting automated gestures.
- **Unit Testing**: 
  - Added coverage in `OverlayMenuTests` and `OverlayManagerTests` for verifying that window touchability flags and layout params are correctly propagated and restored during menu stop/start/restarts.
  - Created `AndroidActionExecutorImplTests` to verify that `GestureDispatchListener` callbacks are correctly triggered before and after gesture execution.

### Rationale

The previous implementation of touch passthrough was too broad, applying touch-region shaping by default across many overlay UIs. This caused unintended passthrough behavior. This updated approach is much cleaner and ensures passthrough is strictly confined to the active scenario's debug panel.
