### PR TITLE
Fix migration SQL escaping for notification counter text

### DIFF
--- a/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/migrations/SQLiteTable.kt
+++ b/core/common/base/src/main/java/com/buzbuz/smartautoclicker/core/base/migrations/SQLiteTable.kt
@@ -113,6 +113,26 @@ class SQLiteTable internal constructor(
         """.trimIndent()
     )
 
+    fun updateValues(extraClause: String?, contentValues: ContentValues) {
+        val bindArgs = mutableListOf<Any>()
+        val updatedValues = contentValues.valueSet().map { (key, value) ->
+            if (value == null) key to "NULL"
+            else {
+                bindArgs += value.formatAsSQLiteBindArg()
+                key to "?"
+            }
+        }
+
+        execSQLite(
+            """
+                UPDATE `$tableName`
+                SET ${updatedValues.formatAsSQLiteUpdateList()}
+                ${extraClause.formatAsOptionalClause()}
+            """.trimIndent(),
+            bindArgs.toTypedArray(),
+        )
+    }
+
     fun deleteFrom(primaryKeys: Set<Long>): Unit = execSQLite(
         """
             DELETE FROM `$tableName` 
@@ -169,6 +189,11 @@ class SQLiteTable internal constructor(
         databaseSQLite.execSQL(statement)
     }
 
+    private fun execSQLite(statement: String, bindArgs: Array<Any>) {
+        Log.d(TAG, "Executing: $statement")
+        databaseSQLite.execSQL(statement, bindArgs)
+    }
+
     private fun querySQLite(query: String): Cursor {
         Log.d(TAG, "Executing: $query")
         return databaseSQLite.query(query)
@@ -178,6 +203,12 @@ class SQLiteTable internal constructor(
         Log.d(TAG, "Inserting into $tableName: $contentValues")
         return databaseSQLite.insert(tableName, CONFLICT_FAIL, contentValues)
     }
+
+    private fun Any.formatAsSQLiteBindArg(): Any =
+        when (this) {
+            is Boolean -> if (this) "1" else "0"
+            else -> this
+        }
 }
 
 private const val TAG = "SQLiteTable"

--- a/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20.kt
+++ b/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20.kt
@@ -288,7 +288,7 @@ object Migration19to20 : Migration(19, 20) {
         },
     )
 
-    private fun SQLiteTable.updateNotificationCounterText(actionId: Long, text: String) = update(
+    private fun SQLiteTable.updateNotificationCounterText(actionId: Long, text: String) = updateValues(
         extraClause = "WHERE `id` = $actionId",
         contentValues = ContentValues().apply {
             put(notificationMessageTextColumn.name, text)
@@ -298,7 +298,7 @@ object Migration19to20 : Migration(19, 20) {
     private fun SQLiteTable.restoreFrameLimitValue(scenarioId: Long, computeRate: Double) = update(
         extraClause = "WHERE `id` = $scenarioId",
         contentValues = ContentValues().apply {
-            put(scenarioComputeRateColumn.name, computeRate.toString())
+            put(scenarioComputeRateColumn.name, computeRate)
         },
     )
 }

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20Tests.kt
@@ -34,6 +34,7 @@ import com.buzbuz.smartautoclicker.core.database.EVENT_TABLE
 import com.buzbuz.smartautoclicker.core.database.SCENARIO_TABLE
 import com.buzbuz.smartautoclicker.core.database.entity.ActionType
 import com.buzbuz.smartautoclicker.core.database.entity.ConditionType
+import com.buzbuz.smartautoclicker.core.database.entity.NotificationMessageType
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -141,6 +142,35 @@ class Migration19to20Tests {
     }
 
     @Test
+    fun migrate_notification_counter_text_escapes_sql_value() {
+        // Given
+        val scenarioId = 1L
+        val actionId = 860L
+        val counterName = "ConnectionError"
+        val expectedText = "ConnectionError = {ConnectionError}"
+
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { db ->
+            db.insertTestScenario(scenarioId)
+            db.insertTestEvent(1L, scenarioId)
+            db.insertTestAction(
+                id = actionId,
+                eventId = 1L,
+                type = ActionType.NOTIFICATION,
+                notificationMessageCounterName = counterName,
+            )
+        }
+
+        // When
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration19to20).use { db ->
+            // Then
+            db.query("SELECT notification_message_text FROM $ACTION_TABLE WHERE id = $actionId").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(expectedText, cursor.getString(0))
+            }
+        }
+    }
+
+    @Test
     fun migrate_counters_creation_condition_only() {
         // Given
         val scenarioId = 1L
@@ -232,6 +262,8 @@ class Migration19to20Tests {
         counterOperationValue: Int? = null,
         counterOperationCounterName: String? = null,
         notificationMessageCounterName: String? = null,
+        notificationMessageType: NotificationMessageType? =
+            if (notificationMessageCounterName != null) NotificationMessageType.COUNTER_VALUE else null,
     ) {
         insert(ACTION_TABLE, 0, ContentValues().apply {
             put("id", id)
@@ -242,6 +274,7 @@ class Migration19to20Tests {
             put("counter_name", counterName)
             put("counter_operation_value", counterOperationValue)
             put("counter_operation_counter_name", counterOperationCounterName)
+            put("notification_message_type", notificationMessageType?.name)
             put("notification_message_counter_name", notificationMessageCounterName)
         })
     }


### PR DESCRIPTION
## Summary
- add a value-bound migration update helper for SQLiteTable
- use it when Migration19to20 rewrites notification counter messages into text
- cover the crash case with a migration regression test

## Root cause
Migration19to20 converts old notification counter messages into the new text-counter format, for example `ConnectionError = {ConnectionError}`. The existing migration update helper writes ContentValues into raw SQL as unescaped SQL snippets, so text containing braces is emitted directly into the statement and SQLite fails while compiling the migration.

The existing `update` helper is kept unchanged because older migrations rely on it for raw SQL expressions. The new `updateValues` helper uses bound arguments for real values, and Migration19to20 uses that path for user text.

## Validation
- Passed in fork hotfix branch: https://github.com/vibhor1102/Smart-AutoClicker/actions/runs/27805537235
- Passed after merging into fork main: https://github.com/vibhor1102/Smart-AutoClicker/actions/runs/27805699536
- Could not run fork verify on this upstream-based branch because the upstream branch does not include the fork workflow file.