### PR TITLE
Fix counter configuration editing

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/OverlayDialog.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/OverlayDialog.kt
@@ -160,8 +160,8 @@ abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, 
 
     /** Hide the software keyboard. */
     private fun hideSoftInput() {
-        dialog?.let {
-            inputMethodManager.hideSoftInputFromWindow(it.window!!.decorView.windowToken, 0)
+        dialog?.window?.decorView?.windowToken?.let { windowToken ->
+            inputMethodManager.hideSoftInputFromWindow(windowToken, 0)
         }
     }
 

--- a/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/dao/CountersDao.kt
+++ b/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/dao/CountersDao.kt
@@ -38,6 +38,6 @@ interface CountersDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertCounter(counter: CountersEntity)
 
-    @Query("DELETE FROM $COUNTERS_TABLE WHERE counterName = :counterName")
-    suspend fun deleteCounter(counterName: String)
+    @Query("DELETE FROM $COUNTERS_TABLE WHERE counterName = :counterName AND scenarioId = :scenarioId")
+    suspend fun deleteCounter(counterName: String, scenarioId: Long)
 }

--- a/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20.kt
+++ b/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20.kt
@@ -128,17 +128,17 @@ object Migration19to20 : Migration(19, 20) {
         getSQLiteTableReference(ACTION_TABLE).apply {
             forEachActionCounterMention { sourceVal1, sourceVal2, sourceVal3, scenarioId ->
                 if (scenarioId == null) return@forEachActionCounterMention
-                sourceVal1?.let { value -> countersFound.add(value to scenarioId) }
-                sourceVal2?.let { value -> countersFound.add(value to scenarioId) }
-                sourceVal3?.let { value -> countersFound.add(value to scenarioId) }
+                sourceVal1.addCounterIfNamed(scenarioId, countersFound)
+                sourceVal2.addCounterIfNamed(scenarioId, countersFound)
+                sourceVal3.addCounterIfNamed(scenarioId, countersFound)
             }
         }
         getSQLiteTableReference(CONDITION_TABLE).apply {
             forEachConditionsCounterMention { sourceVal1, sourceVal2, sourceVal3, scenarioId ->
                 if (scenarioId == null) return@forEachConditionsCounterMention
-                sourceVal1?.let { value -> countersFound.add(value to scenarioId) }
-                sourceVal2?.let { value -> countersFound.add(value to scenarioId) }
-                sourceVal3?.let { value -> countersFound.add(value to scenarioId) }
+                sourceVal1.addCounterIfNamed(scenarioId, countersFound)
+                sourceVal2.addCounterIfNamed(scenarioId, countersFound)
+                sourceVal3.addCounterIfNamed(scenarioId, countersFound)
             }
         }
 
@@ -154,6 +154,11 @@ object Migration19to20 : Migration(19, 20) {
                 )
             }
         }
+    }
+
+    private fun String?.addCounterIfNamed(scenarioId: Long, countersFound: MutableSet<Pair<String, Long>>) {
+        if (isNullOrBlank()) return
+        countersFound.add(this to scenarioId)
     }
 
     private fun SupportSQLiteDatabase.migrateNotificationActions() {

--- a/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20Tests.kt
+++ b/core/smart/database/src/test/java/com/buzbuz/smartautoclicker/core/database/migrations/Migration19to20Tests.kt
@@ -118,6 +118,26 @@ class Migration19to20Tests {
     }
 
     @Test
+    fun migrate_counters_creation_ignores_blank_counter_names() {
+        // Given
+        helper.createDatabase(dbPath, OLD_DB_VERSION).use { db ->
+            db.insertTestScenario(1L)
+            db.insertTestEvent(1L, 1L)
+            db.insertTestAction(1L, 1L, type = ActionType.CHANGE_COUNTER, counterName = "")
+            db.insertTestCondition(1L, 1L, type = ConditionType.ON_COUNTER_REACHED, counterName = "")
+        }
+
+        // When
+        helper.runMigrationsAndValidate(dbPath, NEW_DB_VERSION, true, Migration19to20).use { db ->
+            // Then
+            db.query("SELECT COUNT(*) FROM $COUNTERS_TABLE").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(0, cursor.getInt(0))
+            }
+        }
+    }
+
+    @Test
     fun migrate_counters_creation_action_only() {
         // Given
         val scenarioId = 1L

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/Repository.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/Repository.kt
@@ -131,10 +131,14 @@ internal class Repository @Inject internal constructor(
         dataSource.getTriggerEventsFlow(scenarioId).mapList { it.toDomainTriggerEvent() }
 
     override fun getCountersFlow(scenarioId: Long): Flow<List<Counter>> =
-        dataSource.getCountersFlow(scenarioId).mapList { it.toDomain() }
+        dataSource.getCountersFlow(scenarioId)
+            .mapList { it.toDomain() }
+            .map { counters -> counters.filter { it.counterName.isNotBlank() } }
 
     override suspend fun getCounters(scenarioId: Long): List<Counter> =
-        dataSource.getCounters(scenarioId).map { it.toDomain() }
+        dataSource.getCounters(scenarioId)
+            .map { it.toDomain() }
+            .filter { it.counterName.isNotBlank() }
 
     override suspend fun getConditionName(conditionId: Identifier): String? =
         dataSource.getConditionName(conditionId.databaseId)

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/data/ScenarioDataSource.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/data/ScenarioDataSource.kt
@@ -519,7 +519,7 @@ internal class ScenarioDataSource @Inject constructor(
             .getScenarioCounters(scenarioDbId)
             .toMutableList()
 
-        newCounters.forEach { counter ->
+        newCounters.filter { counter -> counter.counterName.isNotBlank() }.forEach { counter ->
             // Discard all items added/updated from the to be removed list
             val oldIndex = toBeRemoved.indexOfFirst { oldCounter -> oldCounter.name == counter.counterName }
             if (oldIndex in toBeRemoved.indices) toBeRemoved.remove(toBeRemoved[oldIndex])
@@ -530,7 +530,7 @@ internal class ScenarioDataSource @Inject constructor(
         }
 
         toBeRemoved.forEach { counter ->
-            currentDatabase.value.countersDao().deleteCounter(counter.name)
+            currentDatabase.value.countersDao().deleteCounter(counter.name, scenarioDbId)
         }
     }
 

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/action/ChangeCounter.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/action/ChangeCounter.kt
@@ -46,7 +46,7 @@ data class ChangeCounter(
     }
 
     override fun isComplete(): Boolean =
-        super.isComplete() && counterName.isNotEmpty() && operationValue.isComplete()
+        super.isComplete() && counterName.isNotBlank() && operationValue.isComplete()
 
     override fun hashCodeNoIds(): Int =
         name.hashCode() + counterName.hashCode() + operation.hashCode() + operationValue.hashCode()

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/condition/TriggerCondition.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/condition/TriggerCondition.kt
@@ -49,7 +49,7 @@ sealed class TriggerCondition: Condition() {
     ) : TriggerCondition() {
 
         override fun isComplete(): Boolean =
-            super.isComplete() && counterName.isNotEmpty() && counterValue.isComplete()
+            super.isComplete() && counterName.isNotBlank() && counterValue.isComplete()
 
         override fun hashCodeNoIds(): Int =
             super.hashCode() + counterName.hashCode() + comparisonOperation.hashCode() + counterValue.hashCode()

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/counter/Counter.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/counter/Counter.kt
@@ -30,5 +30,5 @@ data class Counter(
 ): Completable {
 
     override fun isComplete(): Boolean =
-        counterName.isNotEmpty()
+        counterName.isNotBlank()
 }

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/counter/CounterOperationValue.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/model/counter/CounterOperationValue.kt
@@ -28,7 +28,7 @@ sealed class CounterOperationValue : Completable {
     }
 
     data class Counter(override val value: String): CounterOperationValue() {
-        override fun isComplete(): Boolean = value.isNotEmpty()
+        override fun isComplete(): Boolean = value.isNotBlank()
     }
 
     internal companion object {

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/data/CountersEditor.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/data/CountersEditor.kt
@@ -62,10 +62,6 @@ internal class CountersEditor {
         _editedList.value = referenceItems.toList()
     }
 
-    fun saveEditionAsReference() {
-        referenceList.value = _editedList.value
-    }
-
     fun getCounter(name: String): Counter? =
         _editedList.value?.find { counter -> counter.counterName == name }
 
@@ -90,6 +86,10 @@ internal class CountersEditor {
         _editedList.value = currentCounters.toMutableList().apply {
             set(toBeUpdatedIndex, item)
         }
+    }
+
+    fun updateCounters(items: List<Counter>) {
+        _editedList.value = items
     }
 
     fun deleteEditedCounter(item: Counter) {

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/data/CountersEditor.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/data/CountersEditor.kt
@@ -84,7 +84,7 @@ internal class CountersEditor {
 
     fun updateCounter(item: Counter) {
         val currentCounters = _editedList.value ?: emptyList()
-        val toBeUpdatedIndex = currentCounters.indexOf(item)
+        val toBeUpdatedIndex = currentCounters.indexOfFirst { counter -> counter.counterName == item.counterName }
         if (toBeUpdatedIndex !in currentCounters.indices) return
 
         _editedList.value = currentCounters.toMutableList().apply {

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/data/ScenarioEditor.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/data/ScenarioEditor.kt
@@ -149,12 +149,12 @@ internal class ScenarioEditor {
         counterListEditor.updateCounter(item)
     }
 
-    fun deleteCounter(item: Counter) {
-        counterListEditor.deleteEditedCounter(item)
+    fun updateCounters(items: List<Counter>) {
+        counterListEditor.updateCounters(items)
     }
 
-    fun saveCountersEditionAsReference() {
-        counterListEditor.saveEditionAsReference()
+    fun deleteCounter(item: Counter) {
+        counterListEditor.deleteEditedCounter(item)
     }
 
     fun updateImageEventsOrder(newEvents: List<ScreenEvent>) {

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/domain/EditionRepository.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/domain/EditionRepository.kt
@@ -144,12 +144,12 @@ class EditionRepository @Inject constructor(
         scenarioEditor.updateCounter(counter)
     }
 
-    fun deleteCounter(counter: Counter) {
-        scenarioEditor.deleteCounter(counter)
+    fun updateCounters(counters: List<Counter>) {
+        scenarioEditor.updateCounters(counters)
     }
 
-    fun saveCounterEditionsAsReference() {
-        scenarioEditor.saveCountersEditionAsReference()
+    fun deleteCounter(counter: Counter) {
+        scenarioEditor.deleteCounter(counter)
     }
 
     // --- EVENT

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/domain/EditionState.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/domain/EditionState.kt
@@ -59,15 +59,17 @@ internal class EditionState internal constructor(
             editor.editedScenarioState,
             editor.editedScreenEventListState,
             editor.editedTriggerEventListState,
-        ) { scenario, imageEvents, triggerEvents ->
+            editor.editedCountersListState,
+        ) { scenario, imageEvents, triggerEvents, counters ->
 
             if (scenario.value == null || imageEvents.value == null || triggerEvents.value == null)
                 return@combine EditedElementState(value = null, hasChanged = false, canBeSaved = false)
 
             EditedElementState(
                 value = EditedScenarioState(scenario.value, imageEvents.value, triggerEvents.value),
-                hasChanged = scenario.hasChanged || imageEvents.hasChanged || triggerEvents.hasChanged,
+                hasChanged = scenario.hasChanged || imageEvents.hasChanged || triggerEvents.hasChanged || counters.hasChanged,
                 canBeSaved = scenario.canBeSaved && imageEvents.canBeSaved && triggerEvents.canBeSaved
+                        && counters.canBeSaved
                         && (imageEvents.value.isNotEmpty() || triggerEvents.value.isNotEmpty()),
             )
         }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/CounterValueText.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/CounterValueText.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.feature.smart.config.ui.counter
+
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+import java.math.BigDecimal
+
+internal fun Double.toCounterValueText(): String =
+    if (this == 0.0) {
+        "0"
+    } else {
+        BigDecimal.valueOf(this).stripTrailingZeros().toPlainString()
+    }
+
+internal fun View.hideSoftInput() {
+    context.getSystemService(InputMethodManager::class.java)
+        ?.hideSoftInputFromWindow(windowToken, 0)
+}

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigAdapter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigAdapter.kt
@@ -94,10 +94,10 @@ class CountersConfigViewHolder(
             textFieldStartingValue.apply {
                 inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or
                         InputType.TYPE_NUMBER_FLAG_SIGNED
-                imeOptions = EditorInfo.IME_ACTION_SEND or EditorInfo.IME_FLAG_NO_EXTRACT_UI
+                imeOptions = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 setSingleLine(true)
                 setOnEditorActionListener { view, actionId, event ->
-                    if (actionId == EditorInfo.IME_ACTION_SEND || event.isEnterKeyUp()) {
+                    if (actionId == EditorInfo.IME_ACTION_DONE || event.isEnterKeyUp()) {
                         commitStartingValue()
                         view.hideSoftInput()
                         view.clearFocus()

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigAdapter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigAdapter.kt
@@ -16,18 +16,20 @@
  */
 package com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.config
 
+import android.text.InputType
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.widget.doAfterTextChanged
+import android.view.inputmethod.EditorInfo
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.ItemCounterConfigBinding
-
-import java.util.Locale
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.hideSoftInput
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.toCounterValueText
 
 /**
  * Adapter for the list of counters in the configuration.
@@ -80,7 +82,7 @@ class CountersConfigViewHolder(
     onReadByClick: (CounterUiItem) -> Unit,
     onDeleteClick: (CounterUiItem) -> Unit,
     onCounterClicked: (CounterUiItem) -> Unit,
-    onStartingValueChange: (CounterUiItem, Double) -> Unit,
+    private val onStartingValueChange: (CounterUiItem, Double) -> Unit,
     onCancelReplace: () -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
@@ -89,6 +91,29 @@ class CountersConfigViewHolder(
     init {
         binding.apply {
             layoutStartingValue.hint = root.context.getString(R.string.field_label_counter_starting_value)
+            textFieldStartingValue.apply {
+                inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or
+                        InputType.TYPE_NUMBER_FLAG_SIGNED
+                imeOptions = EditorInfo.IME_ACTION_SEND or EditorInfo.IME_FLAG_NO_EXTRACT_UI
+                setSingleLine(true)
+                setOnEditorActionListener { view, actionId, event ->
+                    if (actionId == EditorInfo.IME_ACTION_SEND || event.isEnterKeyUp()) {
+                        commitStartingValue()
+                        view.hideSoftInput()
+                        view.clearFocus()
+                        true
+                    } else {
+                        false
+                    }
+                }
+                setOnFocusChangeListener { view, hasFocus ->
+                    if (!hasFocus) {
+                        commitStartingValue()
+                        normalizeStartingValueText()
+                        view.hideSoftInput()
+                    }
+                }
+            }
 
             contentLayout.setOnClickListener { item?.let(onCounterClicked) }
             buttonExpandCollapse.setOnClickListener { item?.let(onExpandCollapse) }
@@ -96,18 +121,11 @@ class CountersConfigViewHolder(
             readByButton.setOnClickListener { item?.let(onReadByClick) }
             deleteButton.setOnClickListener { item?.let(onDeleteClick) }
             replaceByText.setOnClickListener { onCancelReplace() }
-
-            textFieldStartingValue.doAfterTextChanged { text ->
-                val counter = item ?: return@doAfterTextChanged
-                val newValue = text?.toString()?.toDoubleOrNull() ?: return@doAfterTextChanged
-                if (newValue != counter.startingValue) {
-                    onStartingValueChange(counter, newValue)
-                }
-            }
         }
     }
 
     fun bind(newItem: CounterUiItem) {
+        val isSameCounter = item?.counterName == newItem.counterName
         item = newItem
         binding.apply {
             counterName.text = newItem.counterName
@@ -120,9 +138,8 @@ class CountersConfigViewHolder(
                 readByButton.visibility = View.VISIBLE
                 deleteButton.visibility = View.VISIBLE
 
-                val startingValueText = String.format(Locale.getDefault(), "%s", newItem.startingValue)
-                if (textFieldStartingValue.text.toString() != startingValueText) {
-                    textFieldStartingValue.setText(startingValueText)
+                if (!textFieldStartingValue.hasFocus() || !isSameCounter) {
+                    updateStartingValueText(newItem.startingValue.toCounterValueText())
                 }
             } else {
                 buttonExpandCollapse.setIconResource(R.drawable.ic_chevron_down)
@@ -147,4 +164,33 @@ class CountersConfigViewHolder(
             replaceByText.visibility = if (newItem.selectedForReplacement) View.VISIBLE else View.GONE
         }
     }
+
+    private fun updateStartingValueText(value: String) {
+        binding.textFieldStartingValue.apply {
+            if (text.toString() != value) {
+                setText(value)
+                setSelection(value.length)
+            }
+        }
+    }
+
+    private fun commitStartingValue() {
+        val counter = item ?: return
+        val newValue = binding.textFieldStartingValue.text?.toString()?.toDoubleOrNull() ?: return
+
+        if (newValue != counter.startingValue) {
+            onStartingValueChange(counter, newValue)
+        }
+    }
+
+    private fun normalizeStartingValueText() {
+        val value = binding.textFieldStartingValue.text?.toString()?.toDoubleOrNull()
+            ?: item?.startingValue
+            ?: return
+
+        updateStartingValueText(value.toCounterValueText())
+    }
+
+    private fun KeyEvent?.isEnterKeyUp(): Boolean =
+        this?.keyCode == KeyEvent.KEYCODE_ENTER && this.action == KeyEvent.ACTION_UP
 }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigDialog.kt
@@ -16,12 +16,15 @@
  */
 package com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.config
 
+import android.graphics.Rect
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.RecyclerView
 
 import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
 import com.buzbuz.smartautoclicker.core.common.overlays.dialog.OverlayDialog
@@ -34,6 +37,7 @@ import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.DialogBaseListBinding
 import com.buzbuz.smartautoclicker.feature.smart.config.di.ScenarioConfigViewModelsEntryPoint
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.dialogs.showDeleteConfirmationDialog
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.dialogs.showCloseWithoutSavingDialog
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.creation.CounterCreationDialog
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.reference.CounterReferenceDialog
 
@@ -59,9 +63,10 @@ class CountersConfigDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
                 dialogTitle.setText(R.string.dialog_title_counters_config)
 
                 setButtonVisibility(DialogNavigationButton.DELETE, View.GONE)
-                setButtonVisibility(DialogNavigationButton.SAVE, View.GONE)
+                setButtonVisibility(DialogNavigationButton.SAVE, View.VISIBLE)
                 setButtonVisibility(DialogNavigationButton.DISMISS, View.VISIBLE)
                 buttonDismiss.setDebouncedOnClickListener { back() }
+                buttonSave.setDebouncedOnClickListener { onSaveClicked() }
             }
 
             floatingButtonsLayout.visibility = View.VISIBLE
@@ -80,10 +85,24 @@ class CountersConfigDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
             )
             layoutLoadableList.apply {
                 list.adapter = countersAdapter
+                list.addOnItemTouchListener(object : RecyclerView.SimpleOnItemTouchListener() {
+                    override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+                        clearCounterValueFocusIfTouchOutside(e)
+                        return false
+                    }
+                })
                 setEmptyText(
                     id = R.string.message_empty_counter_name_list_title,
-                    secondaryId =R.string.message_empty_counter_name_list_desc
+                    secondaryId = R.string.message_empty_counter_name_list_desc
                 )
+            }
+            layoutTopBar.root.setOnTouchListener { _, event ->
+                clearCounterValueFocusIfTouchOutside(event)
+                false
+            }
+            floatingButtonsLayout.setOnTouchListener { _, event ->
+                clearCounterValueFocusIfTouchOutside(event)
+                false
             }
         }
 
@@ -98,13 +117,20 @@ class CountersConfigDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
         }
     }
 
-    override fun onDestroy() {
-        viewModel.saveEditions()
-        super.onDestroy()
-    }
-
     override fun back() {
         if (viewModel.getUiState() is CountersUiState.Replacing) return
+        if (viewModel.hasUnsavedModifications()) {
+            context.showCloseWithoutSavingDialog {
+                viewModel.discardChanges()
+                super.back()
+            }
+            return
+        }
+
+        super.back()
+    }
+
+    private fun onSaveClicked() {
         super.back()
     }
 
@@ -142,7 +168,13 @@ class CountersConfigDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
         viewBinding.apply {
             layoutTopBar.setButtonEnabledState(
                 buttonType = DialogNavigationButton.DISMISS,
-                enabled = uiState is CountersUiState.Loaded,
+                enabled = uiState is CountersUiState.Loaded || uiState is CountersUiState.Empty,
+            )
+            layoutTopBar.setButtonEnabledState(
+                buttonType = DialogNavigationButton.SAVE,
+                enabled = uiState.let { state ->
+                    state is CountersUiState.Empty || state is CountersUiState.Loaded && state.canBeSaved
+                },
             )
 
             when (uiState) {
@@ -203,5 +235,20 @@ class CountersConfigDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
             newOverlay = CounterCreationDialog(),
             hideCurrent = false,
         )
+    }
+
+    private fun clearCounterValueFocusIfTouchOutside(event: MotionEvent) {
+        if (event.action != MotionEvent.ACTION_DOWN) return
+
+        val focusedView = dialog?.currentFocus ?: return
+        if (focusedView.id != R.id.text_field_starting_value) return
+        if (focusedView.containsRawPoint(event)) return
+
+        focusedView.clearFocus()
+    }
+
+    private fun View.containsRawPoint(event: MotionEvent): Boolean {
+        val bounds = Rect()
+        return getGlobalVisibleRect(bounds) && bounds.contains(event.rawX.toInt(), event.rawY.toInt())
     }
 }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigViewModel.kt
@@ -28,6 +28,7 @@ import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.G
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.model.CounterReference
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.GetCounterWriteReferencesUseCase
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.ReplaceCounterUseCase
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.toCounterValueText
 
 import dagger.hilt.android.qualifiers.ApplicationContext
 
@@ -49,6 +50,8 @@ class CountersConfigViewModel @Inject constructor(
     private val replaceCounterUseCase: ReplaceCounterUseCase,
     private val editionRepository: EditionRepository,
 ) : ViewModel() {
+
+    private val initialCounters: List<Counter> = editionRepository.editionState.getAllEditedCounters()
 
     private val allCounters: Flow<EditedListState<Counter>> = editionRepository.editionState.editedCountersState
     private val readReferences: Flow<Map<String, Set<CounterReference>>> = getCounterReadReferencesUseCase()
@@ -129,9 +132,18 @@ class CountersConfigViewModel @Inject constructor(
         }
     }
 
-    fun saveEditions() {
-        editionRepository.saveCounterEditionsAsReference()
+    fun discardChanges() {
+        selectedForReplacement.update { null }
+        expandedItems.update { emptySet() }
+        editionRepository.updateCounters(initialCounters)
     }
+
+    fun hasUnsavedModifications(): Boolean =
+        when (val state = uiState.value) {
+            is CountersUiState.Loaded -> state.hasUnsavedModifications
+            is CountersUiState.Replacing -> true
+            else -> false
+        }
 }
 
 private fun Counter.toUiItem(
@@ -171,8 +183,9 @@ private fun Context.getDescription(referencesCount: Int, isExpanded: Boolean, st
         if (referencesCount == 0) getString(R.string.item_counter_desc_expanded_no_reference)
         else getString(R.string.item_counter_desc_expanded_referenced, referencesCount)
     } else {
-        if (referencesCount == 0) getString(R.string.item_counter_desc_collapsed_no_reference, startingValue)
-        else getString(R.string.item_counter_desc_collapsed_referenced, referencesCount, startingValue)
+        val startingValueText = startingValue.toCounterValueText()
+        if (referencesCount == 0) getString(R.string.item_counter_desc_collapsed_no_reference, startingValueText)
+        else getString(R.string.item_counter_desc_collapsed_referenced, referencesCount, startingValueText)
     }
 
 private fun Context.getSetByButtonText(actionsCount: Int): String =

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationDialog.kt
@@ -73,10 +73,10 @@ class CounterCreationDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
             fieldStartingValue.root.hint = context.getString(R.string.field_new_counter_starting_value)
             fieldStartingValue.textField.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or
                     InputType.TYPE_NUMBER_FLAG_SIGNED
-            fieldStartingValue.textField.imeOptions = EditorInfo.IME_ACTION_SEND or EditorInfo.IME_FLAG_NO_EXTRACT_UI
+            fieldStartingValue.textField.imeOptions = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_EXTRACT_UI
             fieldStartingValue.textField.setSingleLine(true)
             fieldStartingValue.textField.setOnEditorActionListener { view, actionId, event ->
-                if (actionId == EditorInfo.IME_ACTION_SEND || event.isEnterKeyUp()) {
+                if (actionId == EditorInfo.IME_ACTION_DONE || event.isEnterKeyUp()) {
                     view.clearFocus()
                     view.hideSoftInput()
                     true

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationDialog.kt
@@ -17,9 +17,11 @@
 package com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.creation
 
 import android.text.InputType
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -34,6 +36,7 @@ import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setError
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.DialogCounterCreationBinding
 import com.buzbuz.smartautoclicker.feature.smart.config.di.ScenarioConfigViewModelsEntryPoint
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.hideSoftInput
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.coroutines.launch
 
@@ -68,8 +71,21 @@ class CounterCreationDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
             fieldName.textField.doAfterTextChanged { viewModel.setName(it.toString()) }
 
             fieldStartingValue.root.hint = context.getString(R.string.field_new_counter_starting_value)
-            fieldStartingValue.textField.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
-            fieldStartingValue.textField.setText("0.0")
+            fieldStartingValue.textField.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or
+                    InputType.TYPE_NUMBER_FLAG_SIGNED
+            fieldStartingValue.textField.imeOptions = EditorInfo.IME_ACTION_SEND or EditorInfo.IME_FLAG_NO_EXTRACT_UI
+            fieldStartingValue.textField.setSingleLine(true)
+            fieldStartingValue.textField.setOnEditorActionListener { view, actionId, event ->
+                if (actionId == EditorInfo.IME_ACTION_SEND || event.isEnterKeyUp()) {
+                    view.clearFocus()
+                    view.hideSoftInput()
+                    true
+                } else {
+                    false
+                }
+            }
+            hideSoftInputOnFocusLoss(fieldStartingValue.textField)
+            fieldStartingValue.textField.setText("0")
             fieldStartingValue.textField.doAfterTextChanged {
                 viewModel.setStartingValue(it.toString().toDoubleOrNull() ?: 0.0)
             }
@@ -97,4 +113,7 @@ class CounterCreationDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
             )
         }
     }
+
+    private fun KeyEvent?.isEnterKeyUp(): Boolean =
+        this?.keyCode == KeyEvent.KEYCODE_ENTER && this.action == KeyEvent.ACTION_UP
 }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationViewModel.kt
@@ -44,7 +44,7 @@ class CountersCreationViewModel @Inject constructor(
 
 
     fun setName(counterName: String) {
-        name.update { counterName }
+        name.update { counterName.trim() }
     }
 
     fun setStartingValue(value: Double) {
@@ -53,7 +53,7 @@ class CountersCreationViewModel @Inject constructor(
 
     fun createCounter() {
         val scenarioId = editionRepository.editionState.getScenario()?.id ?: return
-        val counterName = name.value ?: return
+        val counterName = name.value?.trim() ?: return
         val startingValue = startingValue.value
 
         if (editionRepository.editionState.getCounter(counterName) != null) return

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/selection/CounterSelectionViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/selection/CounterSelectionViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.EditionRepository
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.counter.toCounterValueText
 
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -39,7 +40,7 @@ class CounterSelectionViewModel @Inject constructor(
                     counterName = counter.counterName,
                     counterStartingValueDesc = context.getString(
                         R.string.field_counter_selection_desc,
-                        counter.defaultValue,
+                        counter.defaultValue.toCounterValueText(),
                     )
                 )
             }.sortedBy { counter -> counter.counterName }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/ScenarioDialogViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/ScenarioDialogViewModel.kt
@@ -57,14 +57,15 @@ class ScenarioDialogViewModel @Inject constructor(
         editionRepository.editionState.scenarioState.filterNotNull(),
         editionRepository.editionState.editedScreenEventsState.filterNotNull(),
         editionRepository.editionState.editedTriggerEventsState.filterNotNull(),
-    ) { scenarioState, imageEventsState, triggerEventsState ->
+        editionRepository.editionState.editedCountersState.filterNotNull(),
+    ) { scenarioState, imageEventsState, triggerEventsState, countersState ->
         buildMap {
             put(R.id.page_image_events, imageEventsState.canBeSaved &&
                     (!imageEventsState.value.isNullOrEmpty() || !triggerEventsState.value.isNullOrEmpty()))
             put(R.id.page_trigger_events, triggerEventsState.canBeSaved &&
                     (!imageEventsState.value.isNullOrEmpty() || !triggerEventsState.value.isNullOrEmpty()))
             put(R.id.page_config, scenarioState.canBeSaved)
-            put(R.id.page_more, true)
+            put(R.id.page_more, countersState.canBeSaved)
         }
     }
 

--- a/feature/smart-config/src/main/res/values-ar/strings.xml
+++ b/feature/smart-config/src/main/res/values-ar/strings.xml
@@ -454,8 +454,8 @@
     <string name="dialog_title_counters_config">العدادات</string>
     <string name="message_empty_counter_name_list_title">لا يوجد عداد محدد</string>
     <string name="message_empty_counter_name_list_desc">خزن العداد قيمة رقمية يمكن تغييرها أو التحقق منها أو استخدامها في الإجراءات أو الشروط الخاصة بك</string>
-    <string name="item_counter_desc_collapsed_no_reference">هذا العداد غير مستخدم. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">يُشار إلى هذا العداد %1$d مرة. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">هذا العداد غير مستخدم. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">يُشار إلى هذا العداد %1$d مرة. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">هذا العداد غير مستخدم.</string>
     <string name="item_counter_desc_expanded_referenced">يُشار إلى هذا العداد %1$d مرة.</string>
     <string name="field_label_counter_starting_value">القيمة الابتدائية</string>
@@ -470,7 +470,7 @@
     <string name="field_new_counter_starting_value">القيمة الابتدائية</string>
     <string name="field_counter_name_already_declared">اسم العداد هذا موجود بالفعل</string>
     <string name="field_counter_selection_title_empty">لم يتم اختيار عداد</string>
-    <string name="field_counter_selection_desc">القيمة الابتدائية: %1$.2f</string>
+    <string name="field_counter_selection_desc">القيمة الابتدائية: %1$s</string>
     <string name="field_counter_selection_desc_empty">انقر هنا لاختيار عداد</string>
 
     <string name="dialog_title_copy_fix">حل المشكلات</string>

--- a/feature/smart-config/src/main/res/values-es/strings.xml
+++ b/feature/smart-config/src/main/res/values-es/strings.xml
@@ -454,8 +454,8 @@
     <string name="dialog_title_counters_config">Contadores</string>
     <string name="message_empty_counter_name_list_title">No hay contadores definidos</string>
     <string name="message_empty_counter_name_list_desc">Un contador almacena un valor numérico que se puede modificar, verificar o utilizar en tus acciones o condiciones</string>
-    <string name="item_counter_desc_collapsed_no_reference">Este contador no se usa. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Este contador se referencia %1$d veces. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Este contador no se usa. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Este contador se referencia %1$d veces. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Este contador no se usa.</string>
     <string name="item_counter_desc_expanded_referenced">Este contador se referencia %1$d veces.</string>
     <string name="field_label_counter_starting_value">Valor inicial</string>
@@ -470,7 +470,7 @@
     <string name="field_new_counter_starting_value">Valor inicial</string>
     <string name="field_counter_name_already_declared">Este nombre de contador ya existe</string>
     <string name="field_counter_selection_title_empty">Ningún contador seleccionado</string>
-    <string name="field_counter_selection_desc">Valor inicial: %1$.2f</string>
+    <string name="field_counter_selection_desc">Valor inicial: %1$s</string>
     <string name="field_counter_selection_desc_empty">Toca aquí para seleccionar un contador</string>
 
     <string name="dialog_title_copy_fix">Resolver problemas</string>

--- a/feature/smart-config/src/main/res/values-fr/strings.xml
+++ b/feature/smart-config/src/main/res/values-fr/strings.xml
@@ -432,8 +432,8 @@
     <string name="dialog_title_counters_config">Compteurs</string>
     <string name="message_empty_counter_name_list_title">Aucun compteur défini</string>
     <string name="message_empty_counter_name_list_desc">Un compteur stocke une valeur numérique qui peut être modifiée, vérifiée ou utilisée dans vos actions ou conditions</string>
-    <string name="item_counter_desc_collapsed_no_reference">Ce compteur n\'est pas utilisé. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Ce compteur est référencé %1$d fois. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Ce compteur n\'est pas utilisé. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Ce compteur est référencé %1$d fois. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Ce compteur n\'est pas utilisé.</string>
     <string name="item_counter_desc_expanded_referenced">Ce compteur est référencé %1$d fois.</string>
     <string name="field_label_counter_starting_value">Valeur initiale</string>
@@ -448,7 +448,7 @@
     <string name="field_new_counter_starting_value">Valeur initiale</string>
     <string name="field_counter_name_already_declared">Ce nom de compteur existe déjà</string>
     <string name="field_counter_selection_title_empty">Aucun compteur sélectionné</string>
-    <string name="field_counter_selection_desc">Valeur initiale : %1$.2f</string>
+    <string name="field_counter_selection_desc">Valeur initiale : %1$s</string>
     <string name="field_counter_selection_desc_empty">Cliquez ici pour sélectionner un compteur</string>
 
     <string name="dialog_title_copy_fix">Résoudre les problèmes</string>

--- a/feature/smart-config/src/main/res/values-it/strings.xml
+++ b/feature/smart-config/src/main/res/values-it/strings.xml
@@ -432,8 +432,8 @@
     <string name="field_change_counter_effect_desc_operation">%1$s = %1$s %2$s %3$s</string>
 
     <string name="dialog_title_counters_config">Contatori</string>
-    <string name="item_counter_desc_collapsed_no_reference">Questo contatore non è utilizzato. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Questo contatore è referenziato %1$d volte. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Questo contatore non è utilizzato. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Questo contatore è referenziato %1$d volte. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Questo contatore non è utilizzato.</string>
     <string name="item_counter_desc_expanded_referenced">Questo contatore è referenziato %1$d volte.</string>
     <string name="field_label_counter_starting_value">Valore iniziale</string>
@@ -448,7 +448,7 @@
     <string name="field_new_counter_starting_value">Valore iniziale</string>
     <string name="field_counter_name_already_declared">Questo nome di contatore esiste già</string>
     <string name="field_counter_selection_title_empty">Nessun contatore selezionato</string>
-    <string name="field_counter_selection_desc">Valore iniziale: %1$.2f</string>
+    <string name="field_counter_selection_desc">Valore iniziale: %1$s</string>
     <string name="field_counter_selection_desc_empty">Clicca qui per selezionare un contatore</string>
 
     <string name="dialog_title_copy_fix">Risolvi i problemi</string>

--- a/feature/smart-config/src/main/res/values-ja/strings.xml
+++ b/feature/smart-config/src/main/res/values-ja/strings.xml
@@ -293,8 +293,8 @@
     <string name="dialog_title_counters_config">カウンター</string>
     <string name="message_empty_counter_name_list_title">カウンターが未定義です</string>
     <string name="message_empty_counter_name_list_desc">カウンターには数値が格納され、アクションや条件式内でその値を変更、検証、または使用することができます</string>
-    <string name="item_counter_desc_collapsed_no_reference">このカウンターは未使用です。(%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">このカウンターは %1$d 回参照されています。(%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">このカウンターは未使用です。(%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">このカウンターは %1$d 回参照されています。(%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">このカウンターは未使用です。</string>
     <string name="item_counter_desc_expanded_referenced">このカウンターは %1$d 回参照されています。</string>
     <string name="field_label_counter_starting_value">初期値</string>
@@ -309,7 +309,7 @@
     <string name="field_new_counter_starting_value">初期値</string>
     <string name="field_counter_name_already_declared">このカウンター名はすでに存在します</string>
     <string name="field_counter_selection_title_empty">カウンターが選択されていません</string>
-    <string name="field_counter_selection_desc">初期値: %1$.2f</string>
+    <string name="field_counter_selection_desc">初期値: %1$s</string>
     <string name="field_counter_selection_desc_empty">ここをクリックしてカウンターを選択</string>
 
     <string name="dialog_title_copy_fix">問題を解決</string>

--- a/feature/smart-config/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/smart-config/src/main/res/values-pt-rBR/strings.xml
@@ -450,8 +450,8 @@
     <string name="dialog_title_counters_config">Contadores</string>
     <string name="message_empty_counter_name_list_title">Nenhum contador definido</string>
     <string name="message_empty_counter_name_list_desc">Um contador armazena um valor numérico que pode ser alterado, verificado ou utilizado nas suas ações ou condições</string>
-    <string name="item_counter_desc_collapsed_no_reference">Este contador não está sendo usado. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Este contador é referenciado %1$d vezes. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Este contador não está sendo usado. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Este contador é referenciado %1$d vezes. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Este contador não está sendo usado.</string>
     <string name="item_counter_desc_expanded_referenced">Este contador é referenciado %1$d vezes.</string>
     <string name="field_label_counter_starting_value">Valor inicial</string>
@@ -466,7 +466,7 @@
     <string name="field_new_counter_starting_value">Valor inicial</string>
     <string name="field_counter_name_already_declared">Este nome de contador já existe</string>
     <string name="field_counter_selection_title_empty">Nenhum contador selecionado</string>
-    <string name="field_counter_selection_desc">Valor inicial: %1$.2f</string>
+    <string name="field_counter_selection_desc">Valor inicial: %1$s</string>
     <string name="field_counter_selection_desc_empty">Toque aqui para selecionar um contador</string>
 
     <string name="dialog_title_copy_fix">Resolver problemas</string>

--- a/feature/smart-config/src/main/res/values-ru/strings.xml
+++ b/feature/smart-config/src/main/res/values-ru/strings.xml
@@ -454,8 +454,8 @@
     <string name="dialog_title_counters_config">Счётчики</string>
     <string name="message_empty_counter_name_list_title">Счётчики не определены</string>
     <string name="message_empty_counter_name_list_desc">Счетчик хранит числовое значение, которое можно изменять, проверять или использовать в действиях или условиях</string>
-    <string name="item_counter_desc_collapsed_no_reference">Этот счётчик не используется. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">На этот счётчик ссылаются %1$d раз. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Этот счётчик не используется. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">На этот счётчик ссылаются %1$d раз. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Этот счётчик не используется.</string>
     <string name="item_counter_desc_expanded_referenced">На этот счётчик ссылаются %1$d раз.</string>
     <string name="field_label_counter_starting_value">Начальное значение</string>
@@ -470,7 +470,7 @@
     <string name="field_new_counter_starting_value">Начальное значение</string>
     <string name="field_counter_name_already_declared">Этот счётчик уже существует</string>
     <string name="field_counter_selection_title_empty">Счётчик не выбран</string>
-    <string name="field_counter_selection_desc">Начальное значение: %1$.2f</string>
+    <string name="field_counter_selection_desc">Начальное значение: %1$s</string>
     <string name="field_counter_selection_desc_empty">Нажмите здесь, чтобы выбрать счётчик</string>
 
     <string name="dialog_title_copy_fix">Устранить проблемы</string>

--- a/feature/smart-config/src/main/res/values-uk/strings.xml
+++ b/feature/smart-config/src/main/res/values-uk/strings.xml
@@ -457,8 +457,8 @@
     <string name="dialog_title_counters_config">Лічильники</string>
     <string name="message_empty_counter_name_list_title">Лічильники не визначені</string>
     <string name="message_empty_counter_name_list_desc">Лічильник зберігає числове значення, яке можна змінювати, перевіряти або використовувати у ваших діях чи умовах</string>
-    <string name="item_counter_desc_collapsed_no_reference">Цей лічильник не використовується. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">На цей лічильник посилаються %1$d разів. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Цей лічильник не використовується. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">На цей лічильник посилаються %1$d разів. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Цей лічильник не використовується.</string>
     <string name="item_counter_desc_expanded_referenced">На цей лічильник посилаються %1$d разів.</string>
     <string name="field_label_counter_starting_value">Початкове значення</string>
@@ -473,7 +473,7 @@
     <string name="field_new_counter_starting_value">Початкове значення</string>
     <string name="field_counter_name_already_declared">Цей лічильник вже існує</string>
     <string name="field_counter_selection_title_empty">Лічильник не вибраний</string>
-    <string name="field_counter_selection_desc">Початкове значення: %1$.2f</string>
+    <string name="field_counter_selection_desc">Початкове значення: %1$s</string>
     <string name="field_counter_selection_desc_empty">Натисніть тут, щоб вибрати лічильник</string>
 
     <string name="dialog_title_copy_fix">Вирішити проблеми</string>

--- a/feature/smart-config/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/smart-config/src/main/res/values-zh-rCN/strings.xml
@@ -429,8 +429,8 @@
     <string name="dialog_title_counters_config">计数器</string>
     <string name="message_empty_counter_name_list_title">未定义计数器</string>
     <string name="message_empty_counter_name_list_desc">计数器用于存储一个数值，该数值可在您的操作或条件中进行修改、验证或使用</string>
-    <string name="item_counter_desc_collapsed_no_reference">此计数器未被使用。(%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">此计数器被引用了 %1$d 次。(%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">此计数器未被使用。(%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">此计数器被引用了 %1$d 次。(%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">此计数器未被使用。</string>
     <string name="item_counter_desc_expanded_referenced">此计数器被引用了 %1$d 次。</string>
     <string name="field_label_counter_starting_value">初始值</string>
@@ -445,7 +445,7 @@
     <string name="field_new_counter_starting_value">初始值</string>
     <string name="field_counter_name_already_declared">此计数器名称已存在</string>
     <string name="field_counter_selection_title_empty">未选择计数器</string>
-    <string name="field_counter_selection_desc">初始值：%1$.2f</string>
+    <string name="field_counter_selection_desc">初始值：%1$s</string>
     <string name="field_counter_selection_desc_empty">点击此处选择计数器</string>
 
     <string name="dialog_title_copy_fix">解决问题</string>

--- a/feature/smart-config/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/smart-config/src/main/res/values-zh-rTW/strings.xml
@@ -429,8 +429,8 @@
     <string name="dialog_title_counters_config">計數器</string>
     <string name="message_empty_counter_name_list_title">未定義計數器</string>
     <string name="message_empty_counter_name_list_desc">計數器用於儲存數值，該數值可在您的動作或條件中進行變更、驗證或使用</string>
-    <string name="item_counter_desc_collapsed_no_reference">此計數器未被使用。(%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">此計數器被引用了 %1$d 次。(%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">此計數器未被使用。(%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">此計數器被引用了 %1$d 次。(%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">此計數器未被使用。</string>
     <string name="item_counter_desc_expanded_referenced">此計數器被引用了 %1$d 次。</string>
     <string name="field_label_counter_starting_value">初始值</string>
@@ -445,7 +445,7 @@
     <string name="field_new_counter_starting_value">初始值</string>
     <string name="field_counter_name_already_declared">此計數器名稱已存在</string>
     <string name="field_counter_selection_title_empty">未選擇計數器</string>
-    <string name="field_counter_selection_desc">初始值：%1$.2f</string>
+    <string name="field_counter_selection_desc">初始值：%1$s</string>
     <string name="field_counter_selection_desc_empty">點擊此處選擇計數器</string>
 
     <string name="dialog_title_copy_fix">解決問題</string>

--- a/feature/smart-config/src/main/res/values/strings.xml
+++ b/feature/smart-config/src/main/res/values/strings.xml
@@ -500,8 +500,8 @@
     <string name="message_empty_counter_name_list_title">No counter defined</string>
     <string name="message_empty_counter_name_list_desc">A Counter stores a numeric value that can be changed, verified or used in your Actions or Conditions</string>
 
-    <string name="item_counter_desc_collapsed_no_reference">This counter is unused. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">This counter is referenced %1$d times. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">This counter is unused. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">This counter is referenced %1$d times. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">This counter is unused.</string>
     <string name="item_counter_desc_expanded_referenced">This counter is referenced %1$d times.</string>
 
@@ -521,7 +521,7 @@
     <string name="field_counter_name_already_declared">This counter name already exists</string>
 
     <string name="field_counter_selection_title_empty">No counter selected</string>
-    <string name="field_counter_selection_desc">Starting value: %1$.2f</string>
+    <string name="field_counter_selection_desc">Starting value: %1$s</string>
     <string name="field_counter_selection_desc_empty">Click here to select a counter</string>
 
 


### PR DESCRIPTION
## Summary

This PR fixes several issues in the counter configuration flow introduced with the scenario counters list.

The main goals are:

- avoid creating or keeping counters with blank names;
- make counter edits correctly participate in the scenario save state;
- make the starting-value field behave like a normal single-line numeric input;
- keep whole-number counter values visually simple while preserving decimal support.

## Details

### Blank counter names

The v19 to v20 migration builds the new counters table from counter references found in existing actions and conditions. If one of those references is an empty string, the migration currently treats it as a valid counter name and creates an unnamed counter.

This PR changes that path to ignore null, empty, and blank counter names.

The same rule is applied in the surrounding counter handling so the app does not re-expose or re-save invalid counter entries:

- migration skips blank counter references;
- repository/data-source reads filter blank counter names;
- scenario save filters blank counter names;
- counter-related model validation now requires non-blank names.

A migration test was added for the blank-name case.

### Scenario save state

Changing a counter from the counters list should make the scenario dirty and saveable, just like editing other scenario configuration data.

This PR includes the edited counters state in the scenario-level save state and in the "More" page saveability calculation. It also updates counter replacement inside `CountersEditor` to match counters by name rather than full object equality, so changing editable fields such as the starting value replaces the intended counter entry.

### Counter value input

The starting-value field now commits when editing finishes instead of committing on every text change.

The field now:

- uses a signed decimal numeric input type;
- is single-line;
- requests the Done IME action;
- disables fullscreen extract UI;
- commits on Done/Enter or focus loss;
- hides the keyboard when editing ends;
- avoids rewriting the text while the same field is focused;
- normalizes the displayed value after editing ends.

This avoids closing or rebinding the field while the user is still typing, and prevents cursor jumps caused by per-character model updates.

The counter configuration dialog also now shows the Save action, prompts before discarding unsaved counter edits, and clears focus from the starting-value field when the user taps outside it.

### Compact value display

Counter values are still stored and edited as decimals, but display text now removes unnecessary trailing zeros. For example, `2.0` is shown as `2`, while values with meaningful decimals keep them.

This is used for the counter row and counter selection descriptions so the common whole-number case stays readable.

## Validation

- Cherry-picked onto current `upstream/master` without manual conflict resolution.
- Ran `git diff --check upstream/master..HEAD`.
- Added migration test coverage for blank counter names.
- The same functional changes were built and manually exercised in a downstream fork before this upstream PR was prepared.

I did not run a fresh local Android build from this checkout.
