### PR TITLE
4.0.0-beta03 fixes: Fix drag bounds, decimal display, backup warning/corruption, scenario stats, and branded DontKillMyApp link

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuResizeController.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/implementation/common/OverlayMenuResizeController.kt
@@ -136,16 +136,25 @@ internal class OverlayMenuResizeController(
         val width = if (firstChild == null || firstChild.id == resizedContainer.id) {
             resizedContainer.width
         } else {
-            firstChild.children.fold(0) { acc, child ->
-                acc + (
-                    if (child.isGone) 0
-                    else child.width + child.marginStart + child.marginEnd
-                )
-            }
+            firstChild.visibleHorizontalContentSpan()
         }
 
         return Size(width, height)
     }
+}
+
+private fun ViewGroup.visibleHorizontalContentSpan(): Int {
+    var leftBound = Int.MAX_VALUE
+    var rightBound = Int.MIN_VALUE
+
+    children
+        .filterNot { it.isGone }
+        .forEach { child ->
+            leftBound = minOf(leftBound, child.left - child.marginStart)
+            rightBound = maxOf(rightBound, child.right + child.marginEnd)
+        }
+
+    return if (leftBound == Int.MAX_VALUE) 0 else rightBound - leftBound
 }
 
 private data class OverlayTransition(

--- a/core/common/quality/src/main/java/com/buzbuz/smartautoclicker/core/common/quality/ui/AccessibilityTroubleshootingDialog.kt
+++ b/core/common/quality/src/main/java/com/buzbuz/smartautoclicker/core/common/quality/ui/AccessibilityTroubleshootingDialog.kt
@@ -58,6 +58,6 @@ class AccessibilityTroubleshootingDialog : DialogFragment() {
     }
 
     private fun showDontKillMyApp() {
-        context?.safeStartWebBrowserActivity("https://dontkillmyapp.com")
+        context?.safeStartWebBrowserActivity("https://dontkillmyapp.com?app=Klick%27r")
     }
 }

--- a/core/dumb/src/main/java/com/buzbuz/smartautoclicker/core/dumb/data/database/DumbScenarioDao.kt
+++ b/core/dumb/src/main/java/com/buzbuz/smartautoclicker/core/dumb/data/database/DumbScenarioDao.kt
@@ -118,7 +118,7 @@ interface DumbScenarioDao {
      *
      * @return the scenario stats.
      */
-    @Query("SELECT * FROM dumb_scenario_stats_table WHERE id=:scenarioId")
+    @Query("SELECT * FROM dumb_scenario_stats_table WHERE dumb_scenario_id=:scenarioId")
     suspend fun getScenarioStats(scenarioId: Long): DumbScenarioStatsEntity?
 
     /**

--- a/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/dao/ScenarioDao.kt
+++ b/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/dao/ScenarioDao.kt
@@ -103,7 +103,7 @@ interface ScenarioDao {
      *
      * @return the scenario stats.
      */
-    @Query("SELECT * FROM $SCENARIO_USAGE_TABLE WHERE id=:scenarioId")
+    @Query("SELECT * FROM $SCENARIO_USAGE_TABLE WHERE scenario_id=:scenarioId")
     suspend fun getScenarioStats(scenarioId: Long): ScenarioStatsEntity?
 
     /**

--- a/feature/backup/src/main/java/com/buzbuz/smartautoclicker/feature/backup/data/BackupEngine.kt
+++ b/feature/backup/src/main/java/com/buzbuz/smartautoclicker/feature/backup/data/BackupEngine.kt
@@ -65,7 +65,7 @@ internal class BackupEngine(appDataDir: File, private val contentResolver: Conte
         // Create the zip file containing the scenarios and their events conditions.
         withContext(Dispatchers.IO) {
             try {
-                ZipOutputStream(contentResolver.openOutputStream(zipFileUri)).use { zipStream ->
+                ZipOutputStream(contentResolver.openOutputStream(zipFileUri, "wt")).use { zipStream ->
                     dumbScenarios.forEach { dumbScenario ->
                         Log.d(TAG, "Backup dumb scenario ${dumbScenario.scenario.id}")
 
@@ -83,9 +83,9 @@ internal class BackupEngine(appDataDir: File, private val contentResolver: Conte
                         currentProgress++
                         progress.onProgressChanged(currentProgress, smartScenarios.size)
                     }
-
-                    progress.onCompleted(dumbScenarios, smartScenarios, 0, false)
                 }
+
+                progress.onCompleted(dumbScenarios, smartScenarios, 0, false)
             } catch (ioEx: IOException) {
                 Log.e(TAG, "Error while creating backup archive.")
                 progress.onError()

--- a/feature/backup/src/main/java/com/buzbuz/smartautoclicker/feature/backup/data/smart/SmartBackupDataSource.kt
+++ b/feature/backup/src/main/java/com/buzbuz/smartautoclicker/feature/backup/data/smart/SmartBackupDataSource.kt
@@ -119,7 +119,12 @@ internal class SmartBackupDataSource(
         }
 
         if (!screenCompatWarning) {
-            screenCompatWarning = screenSize != Point(backup.screenWidth, backup.screenHeight)
+            screenCompatWarning = hasDifferentScreenSize(
+                currentWidth = screenSize.x,
+                currentHeight = screenSize.y,
+                backupWidth = backup.screenWidth,
+                backupHeight = backup.screenHeight,
+            )
         }
 
         Log.i(TAG, "Smart scenario is valid, has warnings: $screenCompatWarning")
@@ -158,3 +163,15 @@ internal class SmartBackupDataSource(
 
 /** Tag for logs. */
 private const val TAG = "SmartBackupEngine"
+
+internal fun hasDifferentScreenSize(
+    currentWidth: Int,
+    currentHeight: Int,
+    backupWidth: Int,
+    backupHeight: Int,
+): Boolean {
+    val sameOrientation = currentWidth == backupWidth && currentHeight == backupHeight
+    val rotatedOrientation = currentWidth == backupHeight && currentHeight == backupWidth
+
+    return !sameOrientation && !rotatedOrientation
+}

--- a/feature/backup/src/test/java/com/buzbuz/smartautoclicker/feature/backup/data/smart/SmartBackupDataSourceTests.kt
+++ b/feature/backup/src/test/java/com/buzbuz/smartautoclicker/feature/backup/data/smart/SmartBackupDataSourceTests.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.feature.backup.data.smart
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SmartBackupDataSourceTests {
+
+    @Test
+    fun sameScreenSize_sameOrientation_noWarning() {
+        assertFalse(hasDifferentScreenSize(1080, 2400, 1080, 2400))
+    }
+
+    @Test
+    fun sameScreenSize_differentOrientation_noWarning() {
+        assertFalse(hasDifferentScreenSize(1080, 2400, 2400, 1080))
+    }
+
+    @Test
+    fun differentScreenSize_warning() {
+        assertTrue(hasDifferentScreenSize(1080, 2400, 1440, 3200))
+    }
+}

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/bindings/ItemScreenConditionBindingExt.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/bindings/ItemScreenConditionBindingExt.kt
@@ -28,6 +28,7 @@ import com.buzbuz.smartautoclicker.feature.smart.config.databinding.IncludeScree
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.condition.UiScreenCondition
 import com.buzbuz.smartautoclicker.core.ui.utils.setColorIndicatorDrawable
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toEffectDescription
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 import kotlinx.coroutines.Job
 
@@ -79,7 +80,7 @@ fun IncludeScreenConditionCardBinding.bind(
             conditionText.visibility = View.VISIBLE
 
             conditionText.text = condition.comparisonOperation
-                .toEffectDescription(root.context, operand = condition.counterValue.value.toString())
+                .toEffectDescription(root.context, operand = condition.counterValue.toNaturalDisplayString())
             null
         }
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/bindings/counter/IncludeCounterSelectionBindingExt.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/bindings/counter/IncludeCounterSelectionBindingExt.kt
@@ -19,6 +19,7 @@ package com.buzbuz.smartautoclicker.feature.smart.config.ui.common.bindings.coun
 import com.buzbuz.smartautoclicker.core.base.extensions.setLeftCompoundDrawable
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.IncludeCounterSelectionBinding
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.counter.UiStaticOrCounterSelection
 
 import androidx.appcompat.R as AppCompatR
@@ -40,7 +41,7 @@ fun IncludeCounterSelectionBinding.setCounter(uiState: UiStaticOrCounterSelectio
         title.setLeftCompoundDrawable(null)
         description.text = root.context.getString(
             R.string.field_counter_selection_desc,
-            uiState.counter.defaultValue,
+            uiState.counter.defaultValue.toNaturalDisplayString(maxFractionDigits = 2),
         )
         description.setTextColor(MaterialColors.getColor(root, MaterialR.attr.colorOnSurfaceVariant))
     }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/bindings/counter/IncludeStaticOrCounterSelectionBindingExt.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/bindings/counter/IncludeStaticOrCounterSelectionBindingExt.kt
@@ -30,6 +30,7 @@ import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setText
 import com.buzbuz.smartautoclicker.core.ui.utils.NumberInputFilter
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.IncludeStaticOrCounterSelectionBinding
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.counter.UiOperandType
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.counter.UiCounterOperatorDropdownItem
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.counter.UiStaticOrCounterSelection
@@ -104,7 +105,7 @@ fun IncludeStaticOrCounterSelectionBinding.setValueInfo(uiState: UiStaticOrCount
             counterValueLayout.root.visibility = View.GONE
 
             staticValueLayout.setText(
-                uiState.value.toString(),
+                uiState.value.toNaturalDisplayString(),
                 InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL,
             )
         }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/formatters/NumberFormatter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/formatters/NumberFormatter.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters
+
+import com.buzbuz.smartautoclicker.core.domain.model.counter.CounterOperationValue
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+fun Double.toNaturalDisplayString(maxFractionDigits: Int? = null): String {
+    if (!isFinite()) return toString()
+
+    val value = maxFractionDigits
+        ?.let { BigDecimal.valueOf(this).setScale(it, RoundingMode.HALF_UP) }
+        ?: BigDecimal.valueOf(this)
+
+    return value.stripTrailingZeros().toPlainString()
+}
+
+fun CounterOperationValue.toNaturalDisplayString(): String =
+    when (this) {
+        is CounterOperationValue.Counter -> value
+        is CounterOperationValue.Number -> value.toNaturalDisplayString()
+    }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/formatters/OperationsFormatter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/formatters/OperationsFormatter.kt
@@ -90,6 +90,6 @@ internal fun CounterOperationValue.toEffectDescription(context: Context, operati
         is CounterOperationValue.Number -> context.getString(
             R.string.message_number_condition_static_value_desc,
             context.getString(operation.toFullNameRes()),
-            value.toString(),
+            value.toNaturalDisplayString(),
         )
     }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/action/UiChangeCounter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/action/UiChangeCounter.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.annotation.DrawableRes
 import com.buzbuz.smartautoclicker.core.domain.model.action.ChangeCounter
 import com.buzbuz.smartautoclicker.feature.smart.config.R
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 
 @DrawableRes
@@ -36,5 +37,5 @@ internal fun ChangeCounter.getDescription(context: Context, inError: Boolean): S
             ChangeCounter.OperationType.MINUS -> "-"
             ChangeCounter.OperationType.SET -> "="
         },
-        operationValue.value.toString(),
+        operationValue.toNaturalDisplayString(),
     )

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/condition/UiTriggerCondition.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/condition/UiTriggerCondition.kt
@@ -23,6 +23,7 @@ import com.buzbuz.smartautoclicker.core.domain.model.condition.TriggerCondition
 import com.buzbuz.smartautoclicker.core.domain.model.counter.ComparisonOperation.*
 import com.buzbuz.smartautoclicker.core.ui.utils.formatDuration
 import com.buzbuz.smartautoclicker.feature.smart.config.R
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 
 data class UiTriggerCondition(
@@ -52,7 +53,7 @@ private fun TriggerCondition.getTriggerConditionDescription(context: Context): S
             R.string.item_counter_reached_details,
             counterName,
             getComparisonOperationDisplayName(context),
-            counterValue.value.toString(),
+            counterValue.toNaturalDisplayString(),
         )
 
         is TriggerCondition.OnTimerReached -> context.getString(

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/counter/UiStaticOrCounterSelection.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/model/counter/UiStaticOrCounterSelection.kt
@@ -17,6 +17,7 @@
 package com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.counter
 
 import com.buzbuz.smartautoclicker.core.domain.model.counter.Counter
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 sealed class UiStaticOrCounterSelection {
     data class StaticValue(val value: Double): UiStaticOrCounterSelection()
@@ -31,6 +32,6 @@ enum class UiOperandType {
 fun UiStaticOrCounterSelection.toDisplayValue(): String =
     when (this) {
         is UiStaticOrCounterSelection.CounterValue -> counter?.counterName ?: "?"
-        is UiStaticOrCounterSelection.StaticValue -> value.toString()
+        is UiStaticOrCounterSelection.StaticValue -> value.toNaturalDisplayString()
     }
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/screen/brief/ScreenConditionsBriefViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/screen/brief/ScreenConditionsBriefViewModel.kt
@@ -50,6 +50,7 @@ import com.buzbuz.smartautoclicker.core.ui.views.itembrief.renderers.TextConditi
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.EditionRepository
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.model.EditedListState
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toEffectDescription
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.model.condition.toUiScreenCondition
 
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -263,6 +264,9 @@ private fun ScreenCondition.Text.toTextItemDescription(): TextConditionDescripti
 
 private fun ScreenCondition.Number.toTextItemDescription(context: Context): TextConditionDescription =
     TextConditionDescription(
-        conditionText = comparisonOperation.toEffectDescription(context, operand = counterValue.value.toString()),
+        conditionText = comparisonOperation.toEffectDescription(
+            context = context,
+            operand = counterValue.toNaturalDisplayString(),
+        ),
         conditionDetectionArea = detectionArea,
     )

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigAdapter.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigAdapter.kt
@@ -28,9 +28,9 @@ import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setOnTextChangedListe
 import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setText
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.ItemCounterConfigBinding
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 import com.google.android.material.textfield.TextInputLayout
-import java.util.Locale
 
 /**
  * Adapter for the list of counters in the configuration.
@@ -132,7 +132,7 @@ class CountersConfigViewHolder(
                 readByButton.visibility = View.VISIBLE
                 deleteButton.visibility = View.VISIBLE
 
-                val startingValueText = String.format(Locale.getDefault(), "%s", newItem.startingValue)
+                val startingValueText = newItem.startingValue.toNaturalDisplayString()
                 layoutStartingValue.setText(startingValueText, InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL)
             } else {
                 buttonExpandCollapse.setIconResource(R.drawable.ic_chevron_down)

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/config/CountersConfigViewModel.kt
@@ -28,6 +28,7 @@ import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.G
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.model.CounterReference
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.GetCounterWriteReferencesUseCase
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.usecase.counter.ReplaceCounterUseCase
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 import dagger.hilt.android.qualifiers.ApplicationContext
 
@@ -171,8 +172,10 @@ private fun Context.getDescription(referencesCount: Int, isExpanded: Boolean, st
         if (referencesCount == 0) getString(R.string.item_counter_desc_expanded_no_reference)
         else getString(R.string.item_counter_desc_expanded_referenced, referencesCount)
     } else {
-        if (referencesCount == 0) getString(R.string.item_counter_desc_collapsed_no_reference, startingValue)
-        else getString(R.string.item_counter_desc_collapsed_referenced, referencesCount, startingValue)
+        val startingValueText = startingValue.toNaturalDisplayString(maxFractionDigits = 2)
+
+        if (referencesCount == 0) getString(R.string.item_counter_desc_collapsed_no_reference, startingValueText)
+        else getString(R.string.item_counter_desc_collapsed_referenced, referencesCount, startingValueText)
     }
 
 private fun Context.getSetByButtonText(actionsCount: Int): String =

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/creation/CounterCreationDialog.kt
@@ -69,7 +69,7 @@ class CounterCreationDialog : OverlayDialog(R.style.ScenarioConfigTheme) {
 
             fieldStartingValue.root.hint = context.getString(R.string.field_new_counter_starting_value)
             fieldStartingValue.textField.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
-            fieldStartingValue.textField.setText("0.0")
+            fieldStartingValue.textField.setText("0")
             fieldStartingValue.textField.doAfterTextChanged {
                 viewModel.setStartingValue(it.toString().toDoubleOrNull() ?: 0.0)
             }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/selection/CounterSelectionViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/counter/selection/CounterSelectionViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.domain.EditionRepository
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -39,7 +40,7 @@ class CounterSelectionViewModel @Inject constructor(
                     counterName = counter.counterName,
                     counterStartingValueDesc = context.getString(
                         R.string.field_counter_selection_desc,
-                        counter.defaultValue,
+                        counter.defaultValue.toNaturalDisplayString(maxFractionDigits = 2),
                     )
                 )
             }.sortedBy { counter -> counter.counterName }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/config/ScenarioConfigContent.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/config/ScenarioConfigContent.kt
@@ -43,6 +43,7 @@ import com.buzbuz.smartautoclicker.core.ui.utils.MinMaxDoubleInputFilter
 import com.buzbuz.smartautoclicker.feature.smart.config.R
 import com.buzbuz.smartautoclicker.feature.smart.config.databinding.ContentScenarioConfigBinding
 import com.buzbuz.smartautoclicker.feature.smart.config.di.ScenarioConfigViewModelsEntryPoint
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 import com.google.android.material.textfield.TextInputLayout
 
 import kotlinx.coroutines.launch
@@ -157,7 +158,7 @@ class ScenarioConfigContent(appContext: Context) : NavBarDialogContent(appContex
             editFpsLimit.textLayout.isEnabled = state.isEnabled
             if (state.isEnabled) {
                 editFpsLimit.textField.filters = arrayOf(MinMaxDoubleInputFilter(min = 0.0, max = state.maxValue))
-                editFpsLimit.setText(state.value.toString(), InputType.TYPE_NUMBER_FLAG_DECIMAL)
+                editFpsLimit.setText(state.value.toNaturalDisplayString(), InputType.TYPE_NUMBER_FLAG_DECIMAL)
             } else {
                 editFpsLimit.textField.filters = emptyArray<InputFilter>()
                 editFpsLimit.setText(context.getString(R.string.field_scenario_fps_limit_disable_rate))

--- a/feature/smart-config/src/main/res/values-ar/strings.xml
+++ b/feature/smart-config/src/main/res/values-ar/strings.xml
@@ -454,8 +454,8 @@
     <string name="dialog_title_counters_config">العدادات</string>
     <string name="message_empty_counter_name_list_title">لا يوجد عداد محدد</string>
     <string name="message_empty_counter_name_list_desc">خزن العداد قيمة رقمية يمكن تغييرها أو التحقق منها أو استخدامها في الإجراءات أو الشروط الخاصة بك</string>
-    <string name="item_counter_desc_collapsed_no_reference">هذا العداد غير مستخدم. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">يُشار إلى هذا العداد %1$d مرة. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">هذا العداد غير مستخدم. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">يُشار إلى هذا العداد %1$d مرة. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">هذا العداد غير مستخدم.</string>
     <string name="item_counter_desc_expanded_referenced">يُشار إلى هذا العداد %1$d مرة.</string>
     <string name="field_label_counter_starting_value">القيمة الابتدائية</string>
@@ -470,7 +470,7 @@
     <string name="field_new_counter_starting_value">القيمة الابتدائية</string>
     <string name="field_counter_name_already_declared">اسم العداد هذا موجود بالفعل</string>
     <string name="field_counter_selection_title_empty">لم يتم اختيار عداد</string>
-    <string name="field_counter_selection_desc">القيمة الابتدائية: %1$.2f</string>
+    <string name="field_counter_selection_desc">القيمة الابتدائية: %1$s</string>
     <string name="field_counter_selection_desc_empty">انقر هنا لاختيار عداد</string>
 
     <string name="dialog_title_copy_fix">حل المشكلات</string>

--- a/feature/smart-config/src/main/res/values-es/strings.xml
+++ b/feature/smart-config/src/main/res/values-es/strings.xml
@@ -454,8 +454,8 @@
     <string name="dialog_title_counters_config">Contadores</string>
     <string name="message_empty_counter_name_list_title">No hay contadores definidos</string>
     <string name="message_empty_counter_name_list_desc">Un contador almacena un valor numérico que se puede modificar, verificar o utilizar en tus acciones o condiciones</string>
-    <string name="item_counter_desc_collapsed_no_reference">Este contador no se usa. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Este contador se referencia %1$d veces. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Este contador no se usa. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Este contador se referencia %1$d veces. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Este contador no se usa.</string>
     <string name="item_counter_desc_expanded_referenced">Este contador se referencia %1$d veces.</string>
     <string name="field_label_counter_starting_value">Valor inicial</string>
@@ -470,7 +470,7 @@
     <string name="field_new_counter_starting_value">Valor inicial</string>
     <string name="field_counter_name_already_declared">Este nombre de contador ya existe</string>
     <string name="field_counter_selection_title_empty">Ningún contador seleccionado</string>
-    <string name="field_counter_selection_desc">Valor inicial: %1$.2f</string>
+    <string name="field_counter_selection_desc">Valor inicial: %1$s</string>
     <string name="field_counter_selection_desc_empty">Toca aquí para seleccionar un contador</string>
 
     <string name="dialog_title_copy_fix">Resolver problemas</string>

--- a/feature/smart-config/src/main/res/values-fr/strings.xml
+++ b/feature/smart-config/src/main/res/values-fr/strings.xml
@@ -432,8 +432,8 @@
     <string name="dialog_title_counters_config">Compteurs</string>
     <string name="message_empty_counter_name_list_title">Aucun compteur défini</string>
     <string name="message_empty_counter_name_list_desc">Un compteur stocke une valeur numérique qui peut être modifiée, vérifiée ou utilisée dans vos actions ou conditions</string>
-    <string name="item_counter_desc_collapsed_no_reference">Ce compteur n\'est pas utilisé. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Ce compteur est référencé %1$d fois. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Ce compteur n\'est pas utilisé. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Ce compteur est référencé %1$d fois. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Ce compteur n\'est pas utilisé.</string>
     <string name="item_counter_desc_expanded_referenced">Ce compteur est référencé %1$d fois.</string>
     <string name="field_label_counter_starting_value">Valeur initiale</string>
@@ -448,7 +448,7 @@
     <string name="field_new_counter_starting_value">Valeur initiale</string>
     <string name="field_counter_name_already_declared">Ce nom de compteur existe déjà</string>
     <string name="field_counter_selection_title_empty">Aucun compteur sélectionné</string>
-    <string name="field_counter_selection_desc">Valeur initiale : %1$.2f</string>
+    <string name="field_counter_selection_desc">Valeur initiale : %1$s</string>
     <string name="field_counter_selection_desc_empty">Cliquez ici pour sélectionner un compteur</string>
 
     <string name="dialog_title_copy_fix">Résoudre les problèmes</string>

--- a/feature/smart-config/src/main/res/values-it/strings.xml
+++ b/feature/smart-config/src/main/res/values-it/strings.xml
@@ -432,8 +432,8 @@
     <string name="field_change_counter_effect_desc_operation">%1$s = %1$s %2$s %3$s</string>
 
     <string name="dialog_title_counters_config">Contatori</string>
-    <string name="item_counter_desc_collapsed_no_reference">Questo contatore non è utilizzato. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Questo contatore è referenziato %1$d volte. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Questo contatore non è utilizzato. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Questo contatore è referenziato %1$d volte. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Questo contatore non è utilizzato.</string>
     <string name="item_counter_desc_expanded_referenced">Questo contatore è referenziato %1$d volte.</string>
     <string name="field_label_counter_starting_value">Valore iniziale</string>
@@ -448,7 +448,7 @@
     <string name="field_new_counter_starting_value">Valore iniziale</string>
     <string name="field_counter_name_already_declared">Questo nome di contatore esiste già</string>
     <string name="field_counter_selection_title_empty">Nessun contatore selezionato</string>
-    <string name="field_counter_selection_desc">Valore iniziale: %1$.2f</string>
+    <string name="field_counter_selection_desc">Valore iniziale: %1$s</string>
     <string name="field_counter_selection_desc_empty">Clicca qui per selezionare un contatore</string>
 
     <string name="dialog_title_copy_fix">Risolvi i problemi</string>

--- a/feature/smart-config/src/main/res/values-ja/strings.xml
+++ b/feature/smart-config/src/main/res/values-ja/strings.xml
@@ -293,8 +293,8 @@
     <string name="dialog_title_counters_config">カウンター</string>
     <string name="message_empty_counter_name_list_title">カウンターが未定義です</string>
     <string name="message_empty_counter_name_list_desc">カウンターには数値が格納され、アクションや条件式内でその値を変更、検証、または使用することができます</string>
-    <string name="item_counter_desc_collapsed_no_reference">このカウンターは未使用です。(%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">このカウンターは %1$d 回参照されています。(%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">このカウンターは未使用です。(%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">このカウンターは %1$d 回参照されています。(%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">このカウンターは未使用です。</string>
     <string name="item_counter_desc_expanded_referenced">このカウンターは %1$d 回参照されています。</string>
     <string name="field_label_counter_starting_value">初期値</string>
@@ -309,7 +309,7 @@
     <string name="field_new_counter_starting_value">初期値</string>
     <string name="field_counter_name_already_declared">このカウンター名はすでに存在します</string>
     <string name="field_counter_selection_title_empty">カウンターが選択されていません</string>
-    <string name="field_counter_selection_desc">初期値: %1$.2f</string>
+    <string name="field_counter_selection_desc">初期値: %1$s</string>
     <string name="field_counter_selection_desc_empty">ここをクリックしてカウンターを選択</string>
 
     <string name="dialog_title_copy_fix">問題を解決</string>

--- a/feature/smart-config/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/smart-config/src/main/res/values-pt-rBR/strings.xml
@@ -450,8 +450,8 @@
     <string name="dialog_title_counters_config">Contadores</string>
     <string name="message_empty_counter_name_list_title">Nenhum contador definido</string>
     <string name="message_empty_counter_name_list_desc">Um contador armazena um valor numérico que pode ser alterado, verificado ou utilizado nas suas ações ou condições</string>
-    <string name="item_counter_desc_collapsed_no_reference">Este contador não está sendo usado. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">Este contador é referenciado %1$d vezes. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Este contador não está sendo usado. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">Este contador é referenciado %1$d vezes. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Este contador não está sendo usado.</string>
     <string name="item_counter_desc_expanded_referenced">Este contador é referenciado %1$d vezes.</string>
     <string name="field_label_counter_starting_value">Valor inicial</string>
@@ -466,7 +466,7 @@
     <string name="field_new_counter_starting_value">Valor inicial</string>
     <string name="field_counter_name_already_declared">Este nome de contador já existe</string>
     <string name="field_counter_selection_title_empty">Nenhum contador selecionado</string>
-    <string name="field_counter_selection_desc">Valor inicial: %1$.2f</string>
+    <string name="field_counter_selection_desc">Valor inicial: %1$s</string>
     <string name="field_counter_selection_desc_empty">Toque aqui para selecionar um contador</string>
 
     <string name="dialog_title_copy_fix">Resolver problemas</string>

--- a/feature/smart-config/src/main/res/values-ru/strings.xml
+++ b/feature/smart-config/src/main/res/values-ru/strings.xml
@@ -454,8 +454,8 @@
     <string name="dialog_title_counters_config">Счётчики</string>
     <string name="message_empty_counter_name_list_title">Счётчики не определены</string>
     <string name="message_empty_counter_name_list_desc">Счетчик хранит числовое значение, которое можно изменять, проверять или использовать в действиях или условиях</string>
-    <string name="item_counter_desc_collapsed_no_reference">Этот счётчик не используется. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">На этот счётчик ссылаются %1$d раз. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Этот счётчик не используется. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">На этот счётчик ссылаются %1$d раз. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Этот счётчик не используется.</string>
     <string name="item_counter_desc_expanded_referenced">На этот счётчик ссылаются %1$d раз.</string>
     <string name="field_label_counter_starting_value">Начальное значение</string>
@@ -470,7 +470,7 @@
     <string name="field_new_counter_starting_value">Начальное значение</string>
     <string name="field_counter_name_already_declared">Этот счётчик уже существует</string>
     <string name="field_counter_selection_title_empty">Счётчик не выбран</string>
-    <string name="field_counter_selection_desc">Начальное значение: %1$.2f</string>
+    <string name="field_counter_selection_desc">Начальное значение: %1$s</string>
     <string name="field_counter_selection_desc_empty">Нажмите здесь, чтобы выбрать счётчик</string>
 
     <string name="dialog_title_copy_fix">Устранить проблемы</string>

--- a/feature/smart-config/src/main/res/values-uk/strings.xml
+++ b/feature/smart-config/src/main/res/values-uk/strings.xml
@@ -457,8 +457,8 @@
     <string name="dialog_title_counters_config">Лічильники</string>
     <string name="message_empty_counter_name_list_title">Лічильники не визначені</string>
     <string name="message_empty_counter_name_list_desc">Лічильник зберігає числове значення, яке можна змінювати, перевіряти або використовувати у ваших діях чи умовах</string>
-    <string name="item_counter_desc_collapsed_no_reference">Цей лічильник не використовується. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">На цей лічильник посилаються %1$d разів. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">Цей лічильник не використовується. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">На цей лічильник посилаються %1$d разів. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">Цей лічильник не використовується.</string>
     <string name="item_counter_desc_expanded_referenced">На цей лічильник посилаються %1$d разів.</string>
     <string name="field_label_counter_starting_value">Початкове значення</string>
@@ -473,7 +473,7 @@
     <string name="field_new_counter_starting_value">Початкове значення</string>
     <string name="field_counter_name_already_declared">Цей лічильник вже існує</string>
     <string name="field_counter_selection_title_empty">Лічильник не вибраний</string>
-    <string name="field_counter_selection_desc">Початкове значення: %1$.2f</string>
+    <string name="field_counter_selection_desc">Початкове значення: %1$s</string>
     <string name="field_counter_selection_desc_empty">Натисніть тут, щоб вибрати лічильник</string>
 
     <string name="dialog_title_copy_fix">Вирішити проблеми</string>

--- a/feature/smart-config/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/smart-config/src/main/res/values-zh-rCN/strings.xml
@@ -429,8 +429,8 @@
     <string name="dialog_title_counters_config">计数器</string>
     <string name="message_empty_counter_name_list_title">未定义计数器</string>
     <string name="message_empty_counter_name_list_desc">计数器用于存储一个数值，该数值可在您的操作或条件中进行修改、验证或使用</string>
-    <string name="item_counter_desc_collapsed_no_reference">此计数器未被使用。(%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">此计数器被引用了 %1$d 次。(%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">此计数器未被使用。(%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">此计数器被引用了 %1$d 次。(%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">此计数器未被使用。</string>
     <string name="item_counter_desc_expanded_referenced">此计数器被引用了 %1$d 次。</string>
     <string name="field_label_counter_starting_value">初始值</string>
@@ -445,7 +445,7 @@
     <string name="field_new_counter_starting_value">初始值</string>
     <string name="field_counter_name_already_declared">此计数器名称已存在</string>
     <string name="field_counter_selection_title_empty">未选择计数器</string>
-    <string name="field_counter_selection_desc">初始值：%1$.2f</string>
+    <string name="field_counter_selection_desc">初始值：%1$s</string>
     <string name="field_counter_selection_desc_empty">点击此处选择计数器</string>
 
     <string name="dialog_title_copy_fix">解决问题</string>

--- a/feature/smart-config/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/smart-config/src/main/res/values-zh-rTW/strings.xml
@@ -429,8 +429,8 @@
     <string name="dialog_title_counters_config">計數器</string>
     <string name="message_empty_counter_name_list_title">未定義計數器</string>
     <string name="message_empty_counter_name_list_desc">計數器用於儲存數值，該數值可在您的動作或條件中進行變更、驗證或使用</string>
-    <string name="item_counter_desc_collapsed_no_reference">此計數器未被使用。(%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">此計數器被引用了 %1$d 次。(%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">此計數器未被使用。(%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">此計數器被引用了 %1$d 次。(%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">此計數器未被使用。</string>
     <string name="item_counter_desc_expanded_referenced">此計數器被引用了 %1$d 次。</string>
     <string name="field_label_counter_starting_value">初始值</string>
@@ -445,7 +445,7 @@
     <string name="field_new_counter_starting_value">初始值</string>
     <string name="field_counter_name_already_declared">此計數器名稱已存在</string>
     <string name="field_counter_selection_title_empty">未選擇計數器</string>
-    <string name="field_counter_selection_desc">初始值：%1$.2f</string>
+    <string name="field_counter_selection_desc">初始值：%1$s</string>
     <string name="field_counter_selection_desc_empty">點擊此處選擇計數器</string>
 
     <string name="dialog_title_copy_fix">解決問題</string>

--- a/feature/smart-config/src/main/res/values/strings.xml
+++ b/feature/smart-config/src/main/res/values/strings.xml
@@ -500,8 +500,8 @@
     <string name="message_empty_counter_name_list_title">No counter defined</string>
     <string name="message_empty_counter_name_list_desc">A Counter stores a numeric value that can be changed, verified or used in your Actions or Conditions</string>
 
-    <string name="item_counter_desc_collapsed_no_reference">This counter is unused. (%1$.2f)</string>
-    <string name="item_counter_desc_collapsed_referenced">This counter is referenced %1$d times. (%2$.2f)</string>
+    <string name="item_counter_desc_collapsed_no_reference">This counter is unused. (%1$s)</string>
+    <string name="item_counter_desc_collapsed_referenced">This counter is referenced %1$d times. (%2$s)</string>
     <string name="item_counter_desc_expanded_no_reference">This counter is unused.</string>
     <string name="item_counter_desc_expanded_referenced">This counter is referenced %1$d times.</string>
 
@@ -521,7 +521,7 @@
     <string name="field_counter_name_already_declared">This counter name already exists</string>
 
     <string name="field_counter_selection_title_empty">No counter selected</string>
-    <string name="field_counter_selection_desc">Starting value: %1$.2f</string>
+    <string name="field_counter_selection_desc">Starting value: %1$s</string>
     <string name="field_counter_selection_desc_empty">Click here to select a counter</string>
 
 

--- a/feature/smart-config/src/test/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/formatters/NumberFormatterTests.kt
+++ b/feature/smart-config/src/test/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/common/formatters/NumberFormatterTests.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters
+
+import com.buzbuz.smartautoclicker.core.domain.model.counter.CounterOperationValue
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NumberFormatterTests {
+
+    @Test
+    fun wholeNumber_removesUselessDecimal() {
+        assertEquals("1", 1.0.toNaturalDisplayString())
+    }
+
+    @Test
+    fun zero_removesUselessDecimal() {
+        assertEquals("0", 0.0.toNaturalDisplayString())
+    }
+
+    @Test
+    fun negativeWholeNumber_removesUselessDecimal() {
+        assertEquals("-5", (-5.0).toNaturalDisplayString())
+    }
+
+    @Test
+    fun decimalValue_keepsMeaningfulDecimal() {
+        assertEquals("1.25", 1.25.toNaturalDisplayString())
+    }
+
+    @Test
+    fun trailingZeroDecimal_removesOnlyUselessZero() {
+        assertEquals("1.5", 1.50.toNaturalDisplayString())
+    }
+
+    @Test
+    fun longDecimal_keepsMeaningfulDecimals() {
+        assertEquals("1.234567", 1.234567.toNaturalDisplayString())
+    }
+
+    @Test
+    fun maxFractionDigits_keepsNaturalDisplayAfterRounding() {
+        assertEquals("1.23", 1.234.toNaturalDisplayString(maxFractionDigits = 2))
+        assertEquals("1.2", 1.20.toNaturalDisplayString(maxFractionDigits = 2))
+        assertEquals("1", 1.0.toNaturalDisplayString(maxFractionDigits = 2))
+    }
+
+    @Test
+    fun counterOperationNumber_formatsWrappedNumber() {
+        assertEquals("1.5", CounterOperationValue.Number(1.50).toNaturalDisplayString())
+    }
+
+    @Test
+    fun counterOperationCounter_keepsCounterName() {
+        assertEquals("Counter A", CounterOperationValue.Counter("Counter A").toNaturalDisplayString())
+    }
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/details/condition/DebugConditionContentViewModel.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/details/condition/DebugConditionContentViewModel.kt
@@ -38,6 +38,7 @@ import com.buzbuz.smartautoclicker.core.domain.model.counter.ComparisonOperation
 import com.buzbuz.smartautoclicker.core.domain.model.counter.ComparisonOperation.GREATER_OR_EQUALS
 import com.buzbuz.smartautoclicker.core.domain.model.counter.ComparisonOperation.LOWER
 import com.buzbuz.smartautoclicker.core.domain.model.counter.ComparisonOperation.LOWER_OR_EQUALS
+import com.buzbuz.smartautoclicker.core.domain.model.counter.CounterOperationValue
 import com.buzbuz.smartautoclicker.core.domain.model.event.Event
 import com.buzbuz.smartautoclicker.core.domain.model.event.ScreenEvent
 import com.buzbuz.smartautoclicker.core.domain.model.event.TriggerEvent
@@ -60,6 +61,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.math.BigDecimal
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -187,7 +189,7 @@ class DebugConditionContentViewModel @Inject constructor(
                 R.string.item_event_occurrence_details_trigger_desc_counter,
                 counterName,
                 comparisonOperation.getComparisonOperationDisplayName(context),
-                counterValue.value.toString(),
+                counterValue.toNaturalDisplayString(),
             )
             is TriggerCondition.OnTimerReached -> context.getString(
                 R.string.item_event_occurrence_details_trigger_desc_timer,
@@ -231,4 +233,15 @@ class DebugConditionContentViewModel @Inject constructor(
 
     private fun Int.toMinimumConfidence(): Double =
         100.00 - this
+
+    private fun Double.toNaturalDisplayString(): String {
+        if (!isFinite()) return toString()
+        return BigDecimal.valueOf(this).stripTrailingZeros().toPlainString()
+    }
+
+    private fun CounterOperationValue.toNaturalDisplayString(): String =
+        when (this) {
+            is CounterOperationValue.Counter -> value
+            is CounterOperationValue.Number -> value.toNaturalDisplayString()
+        }
 }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/details/counter/adapter/CounterStateViewHolder.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/details/counter/adapter/CounterStateViewHolder.kt
@@ -23,6 +23,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.buzbuz.smartautoclicker.feature.smart.debugging.R
 import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ItemCounterStateBinding
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.details.counter.CounterStateItem
+import java.math.BigDecimal
 
 class CounterStateViewHolder private constructor(
     private val viewBinding: ItemCounterStateBinding,
@@ -46,14 +47,19 @@ class CounterStateViewHolder private constructor(
         return if (oldValue == null) {
             context.getString(
                 R.string.item_counter_state_value_same,
-                currentCounterValue,
+                currentCounterValue.toNaturalDisplayString(),
             )
         } else {
             context.getString(
                 R.string.item_counter_state_value_changed,
-                oldValue,
-                currentCounterValue,
+                oldValue.toNaturalDisplayString(),
+                currentCounterValue.toNaturalDisplayString(),
             )
         }
+    }
+
+    private fun Double.toNaturalDisplayString(): String {
+        if (!isFinite()) return toString()
+        return BigDecimal.valueOf(this).stripTrailingZeros().toPlainString()
     }
 }

--- a/feature/smart-debugging/src/main/res/values/strings.xml
+++ b/feature/smart-debugging/src/main/res/values/strings.xml
@@ -90,8 +90,8 @@
       - DO NOT TRANSLATE.
       -->
     <string name="event_state_changed_separator" translatable="false">"  »  "</string>
-    <string name="item_counter_state_value_same" translatable="false">%1$f</string>
-    <string name="item_counter_state_value_changed" translatable="false">%1$.2f » %2$.2f</string>
+    <string name="item_counter_state_value_same" translatable="false">%1$s</string>
+    <string name="item_counter_state_value_changed" translatable="false">%1$s » %2$s</string>
 
 
 </resources>

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/adapter/ScenarioEventsAdapter.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/adapter/ScenarioEventsAdapter.kt
@@ -32,6 +32,7 @@ import com.buzbuz.smartautoclicker.core.domain.model.condition.ScreenCondition
 import com.buzbuz.smartautoclicker.core.ui.utils.setColorIndicatorDrawable
 import com.buzbuz.smartautoclicker.databinding.ItemEventCardBinding
 import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toEffectDescription
+import com.buzbuz.smartautoclicker.feature.smart.config.ui.common.formatters.toNaturalDisplayString
 import com.buzbuz.smartautoclicker.scenarios.list.model.ScenarioListUiState.Item.ScenarioItem.Valid.Smart.EventItem
 
 import kotlinx.coroutines.Job
@@ -109,7 +110,7 @@ class EventCardViewHolder(
                     conditionText.visibility = View.VISIBLE
 
                     conditionText.text = condition.comparisonOperation
-                        .toEffectDescription(root.context, operand = condition.counterValue.value.toString())
+                        .toEffectDescription(root.context, operand = condition.counterValue.toNaturalDisplayString())
                 }
 
                 is ScreenCondition.Text -> {


### PR DESCRIPTION
## Summary

This PR contains six fixes/improvements for the 4.0.0-beta03 stabilization branch:

- Fix the small unboundable area on the right edge when opening or creating the first scenario after installation. Reopening the overlay previously made the problem disappear.
- Address item 7 from #926 by removing forced `.0` and `.00` suffixes from counter-style values across the app.
- Avoid the false "different screen" warning when a scenario is exported and imported on the same device in different orientations.
- Fix scenario usage stats database queries to target correct foreign key columns instead of primary keys, solving the bug where scenario uses count does not increment.
- Use the branded DontKillMyApp link for Klick'r (`https://dontkillmyapp.com?app=Klick%27r`) to offer users a tailored troubleshooting page.
- Fix ZIP backup corruption when overwriting an existing backup file by forcing write truncation mode ("wt") and postponing completion notification until the stream is fully closed.

## Backup ZIP corruption on overwrite

When overwriting an existing backup file, the default SAF write mode `"w"` does not truncate the file on some devices (e.g. Xiaomi/MIUI/HyperOS). If the new ZIP file is smaller than the old one, the trailing data of the old ZIP (including its EOCD and Central Directory) remains at the end of the file, leading to multiple EOCDs and structural ZIP corruption.

This change opens the output stream with mode `"wt"` to guarantee truncation, and moves `progress.onCompleted` outside the `ZipOutputStream` block so that completion is only triggered after the stream has written all metadata and closed.

Special thanks to @ohlalayeah for providing the initial corrupted backup file ([KlickrSmartAutoClicker-BackupMiPad6SPro.20260704.zip](https://github.com/user-attachments/files/29654202/KlickrSmartAutoClicker-BackupMiPad6SPro.20260704.zip)) that helped isolate this truncation issue.

## Scenario usage statistics

The stats queries in `ScenarioDao` and `DumbScenarioDao` previously queried the stats table using `WHERE id = :scenarioId`. Since `id` is the auto-generated primary key of the stats row itself (and not the scenario's ID), the query fetched the wrong stats row (or returned `null` and inserted duplicates) and misattributed the stats to a different scenario. 

This change updates the queries to correctly use `WHERE scenario_id = :scenarioId` and `WHERE dumb_scenario_id = :scenarioId`.

## Decimal display behavior

Counter values now use a natural display format at UI boundaries:

- `1.0` is displayed as `1`
- `1.50` is displayed as `1.5`
- `1.25` remains `1.25`
- meaningful longer decimal values remain available where the UI does not intentionally limit summary precision

Storage, parsing, migrations, and counter calculations remain unchanged. Numeric fields still accept decimals as before, and saved decimal precision is preserved when editing.

## Backup screen compatibility

The backup check previously compared width and height in their original order. As a result, a scenario exported in landscape at `2400 x 1080` and imported in portrait at `1080 x 2400` was reported as coming from a different screen, even on the same phone.

The check now accepts either the original dimensions or the same dimensions swapped by rotation. A genuinely different resolution still produces the compatibility warning.

## Branded DontKillMyApp link

Uses the branded URL `https://dontkillmyapp.com?app=Klick%27r` in the accessibility troubleshooting dialog so users get the custom-tailored guidance for Klick'r.
- Closes #932 

## Verification

- Added focused formatter tests covering whole numbers, trailing zeros, negatives, zero, meaningful decimals, and long decimal values.
- Added backup compatibility tests for matching orientation, rotated orientation, and genuinely different screen dimensions.
- Scoped smart-config unit test passed locally for the earlier decimal-display change.
- Hosted arm64 debug APK build passed and was installed and tested successfully on an Android 14 device before the backup compatibility commit.
- Reproduced the backup warning on the same Android 14 phone and confirmed the source archive stored `2400 x 1080` while the phone reported `1080 x 2400` during import.
- Inspected SQLite database tables on device before and after reproducing the bug, verifying that opening a scenario now correctly creates/updates the specific scenario's stats row instead of updating a different scenario's row.
- Verified accessibility dialog button points to the updated URL.
- Verified backup ZIP file structure from device showing multiple EOCDs on overwrite, and confirmed the fix truncates the file correctly and ensures single-EOCD compliant ZIP format.
