### PR TITLE
Fix: scope counter deletion and fix coordinate scaling coercion to 0-width/height

### DIFF
--- a/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/dao/CountersDao.kt
+++ b/core/smart/database/src/main/java/com/buzbuz/smartautoclicker/core/database/dao/CountersDao.kt
@@ -38,6 +38,6 @@ interface CountersDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertCounter(counter: CountersEntity)
 
-    @Query("DELETE FROM $COUNTERS_TABLE WHERE counterName = :counterName")
-    suspend fun deleteCounter(counterName: String)
+    @Query("DELETE FROM $COUNTERS_TABLE WHERE counterName = :counterName AND scenarioId = :scenarioId")
+    suspend fun deleteCounter(counterName: String, scenarioId: Long)
 }

--- a/core/smart/detection/src/main/cpp/detector/matching/color/color_matcher.cpp
+++ b/core/smart/detection/src/main/cpp/detector/matching/color/color_matcher.cpp
@@ -35,7 +35,7 @@ ColorMatchingResult *ColorMatcher::getMatchingResults() {
 }
 
 bool ColorMatcher::isRoiValidForMatching(const cv::Rect& screenRoi, const cv::Rect& roi) {
-    if (!isRoiContainsOrEquals(screenRoi, roi)) {
+    if (roi.width <= 0 || roi.height <= 0 || !isRoiContainsOrEquals(screenRoi, roi)) {
         LOGD("Detector", "Can't detect color, detection area (x=%d, y=%d, w=%d, h=%d) is not contained in screen (w=%d, h=%d)",
              roi.x, roi.y, roi.width, roi.height,
              screenRoi.width, screenRoi.height);

--- a/core/smart/detection/src/main/cpp/detector/matching/template/template_matcher.cpp
+++ b/core/smart/detection/src/main/cpp/detector/matching/template/template_matcher.cpp
@@ -41,7 +41,7 @@ bool TemplateMatcher::isRoiValidForMatching(const cv::Rect& screenRoi, const cv:
         return false;
     }
 
-    if (!isRoiContainsOrEquals(screenRoi, roi)) {
+    if (roi.width <= 0 || roi.height <= 0 || !isRoiContainsOrEquals(screenRoi, roi)) {
         LOGD("Detector", "Can't detectCondition, detection area (x=%d, y=%d, w=%d, h=%d) is not contained in screen (w=%d, h=%d)",
              roi.x, roi.y, roi.width, roi.height,
              screenRoi.width, screenRoi.height);

--- a/core/smart/detection/src/main/cpp/detector/matching/text/text_matcher.cpp
+++ b/core/smart/detection/src/main/cpp/detector/matching/text/text_matcher.cpp
@@ -123,7 +123,7 @@ TextMatchingResult* TextMatcher::matchNumber(
 }
 
 bool TextMatcher::isRoiValidForMatching(const cv::Rect& screenRoi, const cv::Rect& roi) {
-    if (!isRoiContainsOrEquals(screenRoi, roi)) {
+    if (roi.width <= 0 || roi.height <= 0 || !isRoiContainsOrEquals(screenRoi, roi)) {
         LOGD("TextMatcher", "Can't detect text, detection area (x=%d, y=%d, w=%d, h=%d) is not contained in screen (w=%d, h=%d)",
              roi.x, roi.y, roi.width, roi.height,
              screenRoi.width, screenRoi.height);

--- a/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/data/ScenarioDataSource.kt
+++ b/core/smart/domain/src/main/java/com/buzbuz/smartautoclicker/core/domain/data/ScenarioDataSource.kt
@@ -530,7 +530,7 @@ internal class ScenarioDataSource @Inject constructor(
         }
 
         toBeRemoved.forEach { counter ->
-            currentDatabase.value.countersDao().deleteCounter(counter.name)
+            currentDatabase.value.countersDao().deleteCounter(counter.name, scenarioDbId)
         }
     }
 

--- a/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/scaling/ScalingManager.kt
+++ b/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/scaling/ScalingManager.kt
@@ -122,8 +122,8 @@ class ScalingManager @Inject constructor(
             screenCondition = this,
             detectionArea = detectionArea
                 .scaleDown()
-                .ensureMinSize()
                 .coerceIn(bounds = scaledScreenSize.toArea())
+                .ensureMinSize()
         )
 
     private fun ScreenCondition.Text.toTextScalingInfo(scaledScreenSize: Point): ScreenConditionScalingInfo.Text =
@@ -131,8 +131,8 @@ class ScalingManager @Inject constructor(
             screenCondition = this,
             detectionArea = detectionArea
                 .scaleDown()
-                .ensureMinSize()
                 .coerceIn(bounds = scaledScreenSize.toArea())
+                .ensureMinSize()
         )
 
     private fun ScreenCondition.Number.toNumberScalingInfo(scaledScreenSize: Point): ScreenConditionScalingInfo.Number =
@@ -140,8 +140,8 @@ class ScalingManager @Inject constructor(
             screenCondition = this,
             detectionArea = detectionArea
                 .scaleDown()
-                .ensureMinSize()
                 .coerceIn(bounds = scaledScreenSize.toArea())
+                .ensureMinSize()
         )
 
     private fun List<ScreenEvent>.toConditionsList(): List<ScreenCondition> =


### PR DESCRIPTION
### Summary
This PR addresses two critical bugs in the 4.0.0-beta03 cycle:
1. **Counter deletion scoping**: Scopes counter deletion to prevent deleting duplicate-named counters globally across different scenarios.
2. **Coordinate scaling coercion to 0-width/height (CRITICAL BUG)**: Fixes a critical scenario matching failure caused by scaling mismatch and coordinate coercion when starting scenarios in portrait orientation.

---

### Bug 1: Counter deletion scoping
* **Cause**: Deleting a counter during scenario update reconciled the counters table globally instead of scoping it by `scenarioId`.
* **Fix**: Scoped the delete query in `CountersDao` to also check `scenarioId`.

---

### Bug 2: Coordinate scaling coercion (CRITICAL)
* **Impact**: This is a critical, silent bug caught just in time. When a user runs a landscape scenario but starts it when the screen is transiently in portrait (e.g., from the overlay menu, home screen, or during lock screen/keyguard active moments), the scenario fails to match *permanently* (producing repeated `screenCroppedColorMat is empty after cropping.` errors) even after transitioning to landscape, until the app is force closed.
* **Why it was hard to diagnose**: This bug would be virtually impossible to reproduce from user feedback alone. A victim would experience scenario matching failing randomly (or after screen-off/lock screen transitions) without any clear trigger, and no amount of user logs/details could trace it since it depends on sub-millisecond transient screen rotation states during initialization.
* **Cause**:
  1. In `ScalingManager.kt`, `.ensureMinSize()` is called before `.coerceIn()`. If coordinates are out of bounds, `.coerceIn` clamps them to the edge, creating a degenerate `0`-width or `0`-height rectangle (e.g. `Rect(540, 200, 540, 300)`).
  2. The JNI boundary check in `isRoiValidForMatching` allows `0`-dimension rectangles to pass.
  3. OpenCV fails to crop a `0`-width matrix, leading to empty cropped warnings and permanent matching failure.
* **Fix**:
  1. Swapped the scaling order in `ScalingManager.kt` to run `.coerceIn` first, and then `.ensureMinSize()`. This guarantees the scaled area has at least `1x1` size.
  2. Hardened `isRoiValidForMatching` in C++ (`color_matcher.cpp`, `template_matcher.cpp`, `text_matcher.cpp`) to explicitly reject any degenerate rectangles where `width <= 0 || height <= 0`.
