### PR TITLE
QoL: Limiters/reloading UX improvements and landscape layout optimization

### DIFF
--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/EventDialog.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/EventDialog.kt
@@ -353,6 +353,10 @@ class EventDialog(
             editCooldownValue.textLayout.isEnabled = uiState.cooldownEnabled
             dropdownCooldownTimeUnit.textLayout.isEnabled = uiState.cooldownEnabled
 
+            val cooldownVisibility = if (uiState.cooldownEnabled) View.VISIBLE else View.GONE
+            editCooldownValue.root.visibility = cooldownVisibility
+            dropdownCooldownTimeUnit.root.visibility = cooldownVisibility
+
             editCooldownValue.setText(uiState.cooldownValue, InputType.TYPE_CLASS_NUMBER)
             dropdownCooldownTimeUnit.setSelectedItem(uiState.cooldownUnit)
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/EventDialogViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/event/EventDialogViewModel.kt
@@ -72,6 +72,8 @@ class EventDialogViewModel @Inject constructor(
     private val userEventCooldownTimeUnit: MutableStateFlow<TimeUnitDropDownItem?> =
         MutableStateFlow(editionRepository.editionState.getEditedEvent<Event>()?.getInitialCooldownTimeUnit())
 
+    private var cachedCooldownMs: Long = editionRepository.editionState.getEditedEvent<ScreenEvent>()?.cooldownMs?.takeIf { it > 0 } ?: 100L
+
     /** Tells if the user is currently editing an event. If that's not the case, dialog should be closed. */
     val isEditingEvent: Flow<Boolean> = editionRepository.isEditingEvent
         .distinctUntilChanged()
@@ -135,8 +137,15 @@ class EventDialogViewModel @Inject constructor(
 
     fun toggleCooldownState() {
         updateEditedEvent { oldValue ->
-            if (oldValue is ScreenEvent) oldValue.copy(cooldownMs = if (oldValue.cooldownMs == 0L) 1 else 0)
-            else oldValue
+            if (oldValue is ScreenEvent) {
+                if (oldValue.cooldownMs == 0L) {
+                    val unit = if (cachedCooldownMs == 100L) TimeUnitDropDownItem.Milliseconds else userEventCooldownTimeUnit.value ?: TimeUnitDropDownItem.Milliseconds
+                    userEventCooldownTimeUnit.update { unit }
+                    oldValue.copy(cooldownMs = cachedCooldownMs)
+                } else {
+                    oldValue.copy(cooldownMs = 0L)
+                }
+            } else oldValue
         }
     }
 
@@ -148,14 +157,15 @@ class EventDialogViewModel @Inject constructor(
         if (value == null || value <= 0L) return
         val timeUnit = userEventCooldownTimeUnit.value ?: return
 
+        val newCooldownMs = when (timeUnit) {
+            TimeUnitDropDownItem.Minutes -> value * 60000
+            TimeUnitDropDownItem.Seconds -> value * 1000
+            else -> value
+        }
+        cachedCooldownMs = newCooldownMs
+
         updateEditedEvent { oldValue ->
-            if (oldValue is ScreenEvent) oldValue.copy(
-                cooldownMs = when (timeUnit) {
-                    TimeUnitDropDownItem.Minutes -> value * 60000
-                    TimeUnitDropDownItem.Seconds -> value * 1000
-                    else -> value
-                }
-            )
+            if (oldValue is ScreenEvent) oldValue.copy(cooldownMs = newCooldownMs)
             else oldValue
         }
     }

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/config/ScenarioConfigContent.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/config/ScenarioConfigContent.kt
@@ -21,6 +21,7 @@ import android.text.InputFilter
 import android.text.InputFilter.LengthFilter
 import android.text.InputType
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 
 import androidx.lifecycle.Lifecycle
@@ -154,6 +155,11 @@ class ScenarioConfigContent(appContext: Context) : NavBarDialogContent(appContex
     private fun updateComputeRate(state: ComputeRateLimitUiState) {
         viewBinding.apply {
             fieldLimitFps.setChecked(state.isEnabled)
+
+            val visibility = if (state.isEnabled) View.VISIBLE else View.GONE
+            editFpsLimit.root.visibility = visibility
+            textSeparator.visibility = visibility
+            fpsTimeUnitField.root.visibility = visibility
 
             editFpsLimit.textLayout.isEnabled = state.isEnabled
             if (state.isEnabled) {

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/config/ScenarioConfigViewModel.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/scenario/config/ScenarioConfigViewModel.kt
@@ -53,6 +53,8 @@ class ScenarioConfigViewModel @Inject constructor(
     private val userComputeRateUnit: MutableStateFlow<ComputeRateUnitDropdownItem?> =
         MutableStateFlow(editionRepository.editionState.getScenario()?.getInitialComputeRateUnitItem())
 
+    private var cachedComputeRate: Double = editionRepository.editionState.getScenario()?.computeRate?.takeIf { it > 0.0 } ?: FRAME_LIMIT_DEFAULT_VALUE
+
     val uiState: StateFlow<ScenarioConfigUiState?> = configuredScenario
         .combine(userComputeRateUnit) { scenario, userUnit ->
             scenario.toUiState(
@@ -95,7 +97,7 @@ class ScenarioConfigViewModel @Inject constructor(
         editionRepository.editionState.getScenario()?.let { scenario ->
             viewModelScope.launch {
                 editionRepository.updateEditedScenario(
-                    scenario.copy(computeRate = if (scenario.computeRate != 0.0) 0.0 else FRAME_LIMIT_DEFAULT_VALUE)
+                    scenario.copy(computeRate = if (scenario.computeRate != 0.0) 0.0 else cachedComputeRate)
                 )
             }
         }
@@ -114,6 +116,8 @@ class ScenarioConfigViewModel @Inject constructor(
             else value
 
         if (newValue > FRAME_LIMIT_MAX_VALUE) return
+
+        cachedComputeRate = newValue
 
         editionRepository.editionState.getScenario()?.let { scenario ->
             viewModelScope.launch {

--- a/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/adapter/ScenarioAdapter.kt
+++ b/smartautoclicker/src/main/java/com/buzbuz/smartautoclicker/scenarios/list/adapter/ScenarioAdapter.kt
@@ -101,6 +101,11 @@ class ScenarioAdapter(
         }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val layoutParams = holder.itemView.layoutParams
+        if (layoutParams is androidx.recyclerview.widget.StaggeredGridLayoutManager.LayoutParams) {
+            layoutParams.isFullSpan = holder is SortViewHolder || holder is EmptyScenarioHolder
+        }
+
         when (holder) {
             is EmptyScenarioHolder -> holder.onBind(getItem(position) as ScenarioListUiState.Item.ScenarioItem.Empty)
             is DumbScenarioViewHolder -> holder.onBind(getItem(position) as ScenarioListUiState.Item.ScenarioItem.Valid.Dumb)

--- a/smartautoclicker/src/main/res/layout-land/fragment_scenarios.xml
+++ b/smartautoclicker/src/main/res/layout-land/fragment_scenarios.xml
@@ -92,7 +92,8 @@
         android:layout_marginBottom="@dimen/margin_vertical_large"
         android:scrollbars="vertical"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layoutManager="androidx.recyclerview.widget.StaggeredGridLayoutManager"
+        app:spanCount="2"
         tools:listitem="@layout/item_smart_scenario"
         tools:visibility="gone"/>
 

--- a/smartautoclicker/src/main/res/layout-land/item_ordering_and_filtering.xml
+++ b/smartautoclicker/src/main/res/layout-land/item_ordering_and_filtering.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+* Copyright (C) 2026 Kevin Buzeau
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/button_group_ordering"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/margin_vertical_small"
+        android:layout_marginStart="@dimen/margin_horizontal_default"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:singleSelection="true"
+        app:selectionRequired="true">
+
+        <Button
+            style="?attr/materialButtonOutlinedStyle"
+            android:id="@+id/button_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/item_scenario_filter_by_name"
+            app:icon="@drawable/ic_sort_name"/>
+
+        <Button
+            style="?attr/materialButtonOutlinedStyle"
+            android:id="@+id/button_recent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/item_scenario_filter_by_recent"
+            app:icon="@drawable/ic_sort_recent"/>
+
+        <Button
+            style="?attr/materialButtonOutlinedStyle"
+            android:id="@+id/button_most_used"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/item_scenario_filter_by_most_used"
+            app:icon="@drawable/ic_most_used"/>
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/chipGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_horizontal_small"
+        app:layout_constraintStart_toEndOf="@id/button_group_ordering"
+        app:layout_constraintEnd_toStartOf="@id/checkbox_sort_order"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintTop_toTopOf="@id/button_group_ordering"
+        app:layout_constraintBottom_toBottomOf="@id/button_group_ordering">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/chip_smart"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/item_title_smart_scenario"
+            app:chipIcon="@drawable/ic_smart"/>
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/chip_dumb"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/item_title_dumb_scenario"
+            app:chipIcon="@drawable/ic_dumb"/>
+
+    </com.google.android.material.chip.ChipGroup>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/checkbox_sort_order"
+        style="@style/AppTheme.Widget.CheckableButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_horizontal_default"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/button_group_ordering"
+        app:layout_constraintBottom_toBottomOf="@id/button_group_ordering"
+        app:icon="@drawable/ic_sort_order"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/smartautoclicker/src/main/res/layout/item_dumb_scenario.xml
+++ b/smartautoclicker/src/main/res/layout/item_dumb_scenario.xml
@@ -29,7 +29,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/margin_horizontal_default"
         android:layout_marginTop="@dimen/margin_vertical_large"
         android:layout_marginBottom="@dimen/margin_vertical_default">

--- a/smartautoclicker/src/main/res/layout/item_smart_scenario.xml
+++ b/smartautoclicker/src/main/res/layout/item_smart_scenario.xml
@@ -29,7 +29,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/margin_horizontal_default"
         android:layout_marginTop="@dimen/margin_vertical_large"
         android:layout_marginBottom="@dimen/margin_vertical_default">


### PR DESCRIPTION
### Summary of Changes

This pull request introduces minor Quality of Life (QoL) improvements to the scenario creation configuration inputs and optimizes the scenario list screen layout for landscape mode.

#### 1. Custom Limiters & Reloading QoL
- **Conditional Input Visibility**: The fields to configure the execution limiter rate and event reloading delay are now hidden dynamically when their respective features are disabled, reducing visual clutter.
- **Customization Retention**: User-configured values for the execution rate and reload delay are now cached in their respective ViewModels, meaning disabling and re-enabling them no longer resets them to default.
- **Improved Default Delay**: Adjusted the default reload delay from a restrictive `1 ms` to a more practical `100 ms` when first enabling the feature.

#### 2. Landscape Layout Optimization (Scenarios List)
- **Staggered Grid Layout**: Converts the landscape scenario list to a 2-column staggered grid (`StaggeredGridLayoutManager`), which allows independent height wrapping for cards in both columns. This prevents collapsed cards next to expanded ones from stretching vertically (fixing empty white spaces and stuck/mixed UI states).
- **Horizontal Header Arrangement**: Rearranges the sorting button group and filter chips to sit side-by-side horizontally in landscape, reducing header height by over 35% (~40dp).
- **Defensive Constraints**: Added layout boundaries to prevent any overlapping on small or split-screen landscape displays.

*(Note: Stacking before/after screenshots showing how visible cards increased from 2 to 6 in landscape mode)*
<img width="3000" height="3000" alt="MixCollage-08-Jul-2026-04-07-PM-7752" src="https://github.com/user-attachments/assets/52ff01c5-1e5c-4736-8be3-94fc745e73dc" />