### PR TITLE
Refresh capture when restoring image and color selectors

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/menu/OverlayMenu.kt
@@ -423,6 +423,14 @@ abstract class OverlayMenu(
     protected open fun onScreenOverlayVisibilityChanged(isVisible: Boolean): Unit = Unit
 
     /**
+     * Called when the user presses the button that toggles the screen overlay visibility.
+     * Return true if the menu handled the requested visibility change itself.
+     *
+     * @param isVisible the visibility requested by the user.
+     */
+    protected open fun onScreenOverlayVisibilityToggleRequested(isVisible: Boolean): Boolean = false
+
+    /**
      * Get the maximum size the window can take.
      * @param backgroundView the background view.
      */
@@ -500,7 +508,10 @@ abstract class OverlayMenu(
         if (resizeController.isAnimating) return
 
         screenOverlayView?.let { view ->
-            setOverlayViewVisibility(view.visibility != View.VISIBLE)
+            val isVisible = view.visibility != View.VISIBLE
+            if (!onScreenOverlayVisibilityToggleRequested(isVisible)) {
+                setOverlayViewVisibility(isVisible)
+            }
         }
     }
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/screen/color/capture/ColorCaptureMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/screen/color/capture/ColorCaptureMenu.kt
@@ -120,6 +120,14 @@ class ColorCaptureMenu (
         }
     }
 
+    override fun onScreenOverlayVisibilityToggleRequested(isVisible: Boolean): Boolean {
+        val pixelSelectionState = viewModel.uiState.value.pixelSelectionUiState
+        if (!isVisible || pixelSelectionState == null) return false
+
+        viewModel.captureScreen(pixelSelectionState.selectedPosition)
+        return true
+    }
+
     private fun updateUiState(uiState: ColorCaptureUiState) {
        updateMenu(uiState)
 

--- a/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/screen/image/CaptureMenu.kt
+++ b/feature/smart-config/src/main/java/com/buzbuz/smartautoclicker/feature/smart/config/ui/condition/screen/image/CaptureMenu.kt
@@ -126,6 +126,17 @@ class CaptureMenu(
         }
     }
 
+    override fun onScreenOverlayVisibilityToggleRequested(isVisible: Boolean): Boolean {
+        if (!isVisible || state != ADJUST) return false
+
+        state = CAPTURE
+        viewModel.takeScreenshot { screenshot ->
+            selectorView.showCapture(screenshot)
+            state = ADJUST
+        }
+        return true
+    }
+
     /**
      * Called when the validity of the selector have changed.
      * Update the buttons to avoid a capture if the selector can't provide the bitmap.


### PR DESCRIPTION
## Summary

- recapture the image selector screenshot when restoring its touch-capture layer with the eye button
- recapture the color picker screenshot on the same restore action, keeping the chosen pixel position
- add a narrow `OverlayMenu` hook so only a direct eye-button action can request this behavior

## Root cause

The eye button only restored the existing overlay view. Both pickers retained their first bitmap, so a changed underlying screen was never captured again.

The initial manual capture step is unchanged.

Fixes #969.

## Validation

- `git diff --check`
- `git show --check`
- Local Gradle builds/tests were intentionally not run; this checkout prohibits local compilation.