### PR TITLE
[i18n] Remove unused tutorial_4/5 locale strings

### DIFF
--- a/feature/tutorial/src/main/res/values-ar/strings.xml
+++ b/feature/tutorial/src/main/res/values-ar/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">ظروف سلبية</string>
-    <string name="item_desc_tutorial_4">تأكد من عدم عرض شيء ما قبل تنفيذ الإجراء</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">سيناريو أحداث متعددة</string>
-    <string name="item_desc_tutorial_5">تعرف على كيفية الجمع بين أحداث متعددة لتحقيق أتمتة معقدة</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-es/strings.xml
+++ b/feature/tutorial/src/main/res/values-es/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">Rastrear una serie de objetivos móviles</string>
-    <string name="item_desc_tutorial_4">Rastrea y haz clic en una serie de objetivos móviles que se mueven</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">Clicar hasta que desaparezcan</string>
-    <string name="item_desc_tutorial_5">Rastrea y haz clic en objetivos móviles hasta que desaparezcan</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-fr/strings.xml
+++ b/feature/tutorial/src/main/res/values-fr/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">Conditions négatives</string>
-    <string name="item_desc_tutorial_4">Vérifiez qu\'un élément n\'est pas affiché avant d\'exécuter une action</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">Scénario avec plusieurs événements</string>
-    <string name="item_desc_tutorial_5">Apprenez à combiner plusieurs événements pour automatiser des tâches complexes</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-it/strings.xml
+++ b/feature/tutorial/src/main/res/values-it/strings.xml
@@ -26,12 +26,8 @@
     <string name="button_text_tutorial_next">Avanti</string>
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">Condizioni negative</string>
-    <string name="item_desc_tutorial_4">Verifica che qualcosa non sia visualizzato prima di eseguire un\'azione</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">Scenario con eventi multipli</string>
-    <string name="item_desc_tutorial_5">Scopri come combinare eventi multipli per realizzare automazioni complesse</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-ja/strings.xml
+++ b/feature/tutorial/src/main/res/values-ja/strings.xml
@@ -7,10 +7,6 @@
     <string name="message_time_left">残り時間: %1$d</string>
     <string name="button_text_tutorial_start_game">ゲームを開始する</string>
     <string name="button_text_tutorial_next">次</string>
-    <string name="item_title_tutorial_4">マイナス条件</string>
-    <string name="item_desc_tutorial_4">アクションを実行する前に、何かが表示されていないことを確認してください</string>
-    <string name="item_title_tutorial_5">複数のイベントのシナリオ</string>
-    <string name="item_desc_tutorial_5">複数のイベントを組み合わせて複雑な自動化を実現する方法を学びます</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/tutorial/src/main/res/values-pt-rBR/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">Condições negativas</string>
-    <string name="item_desc_tutorial_4">Verifique se algo não está sendo exibido antes de executar uma ação</string>
     
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">Cenário de múltiplos eventos</string>
-    <string name="item_desc_tutorial_5">Aprenda a combinar múltiplos eventos para alcançar automação complexa</string>
     
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-ru/strings.xml
+++ b/feature/tutorial/src/main/res/values-ru/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">Отрицательные условия</string>
-    <string name="item_desc_tutorial_4">Проверьте, что что-то не отображается перед выполнением действия</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">Сценарий с несколькими событиями</string>
-    <string name="item_desc_tutorial_5">Научитесь комбинировать несколько событий для достижения сложной автоматизации</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-uk/strings.xml
+++ b/feature/tutorial/src/main/res/values-uk/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">Негативні умови</string>
-    <string name="item_desc_tutorial_4">Перевірте, що щось не відображається перед виконанням дії</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">Сценарій з кількома подіями</string>
-    <string name="item_desc_tutorial_5">Навчіться комбінувати кілька подій для досягнення складної автоматизації</string>
 
 
     <!-- Generic tutorial buttons -->

--- a/feature/tutorial/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/tutorial/src/main/res/values-zh-rCN/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">负条件</string>
-    <string name="item_desc_tutorial_4">在执行操作之前验证某物是否未显示</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">多事件方案</string>
-    <string name="item_desc_tutorial_5">学习如何组合多个事件以实现复杂的自动化</string>
 
     <!-- Generic tutorial buttons -->
     <string name="button_text_tutorial_close">关闭</string>

--- a/feature/tutorial/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/tutorial/src/main/res/values-zh-rTW/strings.xml
@@ -42,12 +42,8 @@
     -->
 
     <!-- Two still targets press when only one is visible tutorial -->
-    <string name="item_title_tutorial_4">負條件</string>
-    <string name="item_desc_tutorial_4">在執行操作之前驗證某物是否未顯示</string>
 
     <!-- Two moving targets press in order tutorial -->
-    <string name="item_title_tutorial_5">多事件情境</string>
-    <string name="item_desc_tutorial_5">學習如何組合多個事件以實現複雜的自動化</string>
 
     <!-- Generic tutorial buttons -->
     <string name="button_text_tutorial_close">關閉</string>


### PR DESCRIPTION
## Summary
- Remove obsolete `item_title/desc_tutorial_4` and `item_title/desc_tutorial_5` from all locales
- Add missing `combine_conditions_not_visible` translations: steps 18–24 and `step_secondary_18`

## Scope
- `feature/tutorial/src/main/res/values-*`
