### PR TITLE
Fix crash when opening floating settings (BadTokenException)

### DIFF
--- a/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/OverlayDialog.kt
+++ b/core/common/overlays/src/main/java/com/buzbuz/smartautoclicker/core/common/overlays/dialog/OverlayDialog.kt
@@ -20,6 +20,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 
@@ -41,7 +42,7 @@ import java.io.PrintWriter
  * This class ensure that all dialogs opened from a service will have the same behaviour. It provides basic lifecycle
  * alike methods to ease the view initialization/cleaning.
  */
-abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, recreateOnRotation = true, useWindowContext = true) {
+abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, recreateOnRotation = true) {
 
     /** The Android InputMethodManger, for ensuring the keyboard dismiss on dialog dismiss. */
     private lateinit var inputMethodManager: InputMethodManager
@@ -105,7 +106,7 @@ abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, 
 
             window?.apply {
                 setType(OverlayManager.OVERLAY_WINDOW_TYPE)
-                setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
+                applySoftInputMode(this)
                 decorView.setOnTouchListener(hideSoftInputTouchListener)
             }
 
@@ -118,6 +119,14 @@ abstract class OverlayDialog(@StyleRes theme: Int? = null) : BaseOverlay(theme, 
         }
 
         onDialogCreated(dialog!!)
+    }
+
+    /** Soft keyboard: resize dialog so input fields stay visible (accessibility overlay). */
+    protected open fun applySoftInputMode(window: Window) {
+        window.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE or
+                WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN,
+        )
     }
 
     @CallSuper


### PR DESCRIPTION
## Summary
- Fix a crash when tapping the floating menu gear/settings button that throws `WindowManager\$BadTokenException: Unable to add window -- token null is not valid`.
- Root cause: `OverlayDialog` enabled `useWindowContext = true` in 9fbe6af1 (IME toolbar on emulator). On some real devices, `BottomSheetDialog.show()` then fails with an invalid window token.
- Change: stop forcing window context for `OverlayDialog` (keep `BaseOverlay.useWindowContext` available for cases that need it), and restore `SOFT_INPUT_ADJUST_RESIZE | SOFT_INPUT_STATE_HIDDEN` so soft-keyboard behavior does not regress.

## Changes
- `OverlayDialog.kt`: drop `useWindowContext = true`; add `applySoftInputMode()` with adjustResize + hidden IME state.

## Notes
- Reproduced on Sony XQ-AT52 (Android 12) with `4.0.0-beta04`; dropbox stack pointed at `Dialog.show` → `BadTokenException`. The main floating menu (`useWindowContext = false`) was unaffected.