### PR TITLE
Add Debug Report condition performance timing foundation

### DIFF
--- a/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/fastscroll/VerticalFastScrollerView.kt
+++ b/core/common/ui/src/main/java/com/buzbuz/smartautoclicker/core/ui/views/fastscroll/VerticalFastScrollerView.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.buzbuz.smartautoclicker.core.ui.views.fastscroll
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import android.view.animation.DecelerateInterpolator
+import androidx.core.content.withStyledAttributes
+import androidx.core.graphics.ColorUtils
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
+
+/** A draggable vertical scrollbar with a usable minimum thumb and touch target. */
+class VerticalFastScrollerView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : View(context, attrs, defStyleAttr) {
+
+    private val density = resources.displayMetrics.density
+    private val idleThumbWidth = 8f * density
+    private val draggingThumbWidth = 14f * density
+    private val idleTrackWidth = 3f * density
+    private val draggingTrackWidth = 8f * density
+    private val minimumThumbHeight = 48f * density
+    private val verticalMargin = 4f * density
+
+    private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val thumbPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val thumbBounds = RectF()
+    private var thumbColor: Int = 0
+    private var dragVisualProgress = 0f
+    private var dragVisualAnimator: ValueAnimator? = null
+
+    private var recyclerView: RecyclerView? = null
+    private var listenerAttached = false
+    private var dragging = false
+    private var dragOffsetY = 0f
+
+    private val scrollListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            updateThumbBounds()
+        }
+    }
+
+    init {
+        context.withStyledAttributes(attrs, intArrayOf(android.R.attr.colorAccent)) {
+            thumbColor = getColor(0, 0)
+        }
+        updatePaintColors()
+        isClickable = true
+    }
+
+    fun attachToRecyclerView(view: RecyclerView) {
+        if (recyclerView === view) return
+        detachScrollListener()
+        recyclerView = view
+        attachScrollListener()
+        view.post(::updateThumbBounds)
+    }
+
+    fun refresh() {
+        post(::updateThumbBounds)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        attachScrollListener()
+        refresh()
+    }
+
+    override fun onDetachedFromWindow() {
+        dragVisualAnimator?.cancel()
+        detachScrollListener()
+        super.onDetachedFromWindow()
+    }
+
+    private fun attachScrollListener() {
+        if (listenerAttached) return
+        recyclerView?.addOnScrollListener(scrollListener)
+        listenerAttached = recyclerView != null
+    }
+
+    private fun detachScrollListener() {
+        if (!listenerAttached) return
+        recyclerView?.removeOnScrollListener(scrollListener)
+        listenerAttached = false
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (thumbBounds.isEmpty) return
+
+        val thumbWidth = lerp(idleThumbWidth, draggingThumbWidth, dragVisualProgress)
+        val trackWidth = lerp(idleTrackWidth, draggingTrackWidth, dragVisualProgress)
+
+        val thumbLeft = edgeAlignedLeft(thumbWidth)
+        val trackLeft = edgeAlignedLeft(trackWidth)
+        canvas.drawRoundRect(
+            trackLeft,
+            verticalMargin,
+            trackLeft + trackWidth,
+            height - verticalMargin,
+            trackWidth / 2f,
+            trackWidth / 2f,
+            trackPaint,
+        )
+        canvas.drawRoundRect(
+            thumbLeft,
+            thumbBounds.top,
+            thumbLeft + thumbWidth,
+            thumbBounds.bottom,
+            thumbWidth / 2f,
+            thumbWidth / 2f,
+            thumbPaint,
+        )
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (thumbBounds.isEmpty) return false
+
+        return when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                val touchTop = thumbBounds.centerY() - max(minimumThumbHeight, thumbBounds.height()) / 2f
+                val touchBottom = thumbBounds.centerY() + max(minimumThumbHeight, thumbBounds.height()) / 2f
+                if (event.y !in touchTop..touchBottom) return false
+
+                parent.requestDisallowInterceptTouchEvent(true)
+                dragging = true
+                dragOffsetY = event.y - thumbBounds.top
+                isPressed = true
+                animateDraggingAppearance(show = true)
+                true
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (!dragging) return false
+                scrollToThumbTop(event.y - dragOffsetY)
+                true
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                if (!dragging) return false
+                dragging = false
+                isPressed = false
+                animateDraggingAppearance(show = false)
+                if (event.actionMasked == MotionEvent.ACTION_UP) performClick()
+                true
+            }
+            else -> dragging
+        }
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    private fun animateDraggingAppearance(show: Boolean) {
+        dragVisualAnimator?.cancel()
+        dragVisualAnimator = ValueAnimator.ofFloat(dragVisualProgress, if (show) 1f else 0f).apply {
+            duration = 140L
+            interpolator = DecelerateInterpolator()
+            addUpdateListener { animator ->
+                dragVisualProgress = animator.animatedValue as Float
+                updatePaintColors()
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    private fun updatePaintColors() {
+        val thumbAlpha = lerp(205f, 255f, dragVisualProgress).toInt()
+        val trackAlpha = lerp(35f, 105f, dragVisualProgress).toInt()
+        thumbPaint.color = ColorUtils.setAlphaComponent(thumbColor, thumbAlpha)
+        trackPaint.color = ColorUtils.setAlphaComponent(thumbColor, trackAlpha)
+    }
+
+    private fun edgeAlignedLeft(elementWidth: Float): Float =
+        if (layoutDirection == LAYOUT_DIRECTION_RTL) 0f else width - elementWidth
+
+    private fun lerp(start: Float, end: Float, progress: Float): Float =
+        start + (end - start) * progress
+
+    private fun scrollToThumbTop(requestedTop: Float) {
+        val list = recyclerView ?: return
+        val travel = height - verticalMargin * 2f - thumbBounds.height()
+        if (travel <= 0f) return
+
+        val top = requestedTop.coerceIn(verticalMargin, verticalMargin + travel)
+        val scrollableRange = list.computeVerticalScrollRange() - list.computeVerticalScrollExtent()
+        val targetOffset = ((top - verticalMargin) / travel * scrollableRange).toInt()
+        list.scrollBy(0, targetOffset - list.computeVerticalScrollOffset())
+    }
+
+    private fun updateThumbBounds() {
+        val list = recyclerView ?: return
+        val extent = list.computeVerticalScrollExtent()
+        val range = list.computeVerticalScrollRange()
+        val availableHeight = height - verticalMargin * 2f
+
+        if (list.visibility != VISIBLE || height == 0 || range <= extent || extent <= 0 || availableHeight <= 0f) {
+            thumbBounds.setEmpty()
+            visibility = INVISIBLE
+            invalidate()
+            return
+        }
+
+        visibility = VISIBLE
+        val thumbHeight = max(minimumThumbHeight, availableHeight * extent / range).coerceAtMost(availableHeight)
+        val travel = availableHeight - thumbHeight
+        val scrollableRange = range - extent
+        val top = verticalMargin + travel * list.computeVerticalScrollOffset() / scrollableRange
+        thumbBounds.set(0f, top, width.toFloat(), top + thumbHeight)
+        invalidate()
+    }
+}

--- a/core/common/ui/src/main/res/drawable/fab_badge_background.xml
+++ b/core/common/ui/src/main/res/drawable/fab_badge_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/colorTertiaryContainer" />
+</shape>

--- a/core/common/ui/src/main/res/layout/include_floating_action_buttons.xml
+++ b/core/common/ui/src/main/res/layout/include_floating_action_buttons.xml
@@ -21,6 +21,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
     android:orientation="vertical"
     android:translationZ="100dp">
 
@@ -32,11 +34,41 @@
         android:visibility="gone"
         tools:visibility="visible"/>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/primary"
-        style="@style/AppTheme.Widget.Fab"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/dialog_create_copy_buttons_bottom_margin"
-        app:srcCompat="@drawable/ic_add"
-        android:contentDescription="@string/content_desc_add_button"/>
+        android:clipChildren="false"
+        android:clipToPadding="false">
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/primary"
+            style="@style/AppTheme.Widget.Fab"
+            app:srcCompat="@drawable/ic_add"
+            android:contentDescription="@string/content_desc_add_button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/primary_badge"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="4dp"
+            android:background="@drawable/fab_badge_background"
+            android:elevation="12dp"
+            android:gravity="center"
+            android:textColor="?attr/colorOnTertiaryContainer"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="@id/primary"
+            app:layout_constraintTop_toTopOf="@id/primary"
+            tools:text="3"
+            tools:visibility="visible" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </LinearLayout>

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/DebugReportLocalDataSource.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/DebugReportLocalDataSource.kt
@@ -27,6 +27,7 @@ import com.buzbuz.smartautoclicker.core.base.extensions.safeRecreate
 import com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping.toDomain
 import com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping.toCountersInitialValues
 import com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping.toProtobuf
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportCounterInitialValue
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportEventOccurrence
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportOverview
@@ -199,6 +200,22 @@ internal class DebugReportLocalDataSource @Inject constructor(
                     }
                 }
             }
+        }
+
+    /** Read aggregate condition timings from the last completed report, if the report contains them. */
+    suspend fun readConditionProfile(): List<ConditionProfile> =
+        filesMutex.withLock {
+            if (isWritingReport) return@withLock emptyList()
+
+            messagesFile.safeInputStream()?.use { inputStream ->
+                while (true) {
+                    val protoMessage = inputStream.safeParseDebugReportMessage() ?: break
+                    if (protoMessage.hasConditionProfileMessage()) {
+                        return@withLock protoMessage.conditionProfileMessage.toDomain()
+                    }
+                }
+            }
+            emptyList()
         }
 
     /** Delete the current report files, if any. */

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/DebugReportLocalDataSource.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/DebugReportLocalDataSource.kt
@@ -203,9 +203,9 @@ internal class DebugReportLocalDataSource @Inject constructor(
         }
 
     /** Read aggregate condition timings from the last completed report, if the report contains them. */
-    suspend fun readConditionProfile(): List<ConditionProfile> =
+    suspend fun readConditionProfile(): List<ConditionProfile>? =
         filesMutex.withLock {
-            if (isWritingReport) return@withLock emptyList()
+            if (isWritingReport) return@withLock null
 
             messagesFile.safeInputStream()?.use { inputStream ->
                 while (true) {
@@ -215,7 +215,7 @@ internal class DebugReportLocalDataSource @Inject constructor(
                     }
                 }
             }
-            emptyList()
+            null
         }
 
     /** Delete the current report files, if any. */

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/ConditionProfileMapping.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/ConditionProfileMapping.kt
@@ -1,0 +1,37 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping
+
+import com.buzbuz.smartautoclicker.core.smart.debugging.ConditionProfileMessageKt.conditionProfileEntry
+import com.buzbuz.smartautoclicker.core.smart.debugging.conditionProfileMessage
+import com.buzbuz.smartautoclicker.core.smart.debugging.debugReportMessage
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
+import com.buzbuz.smartautoclicker.core.smart.debugging.DebugReportMessage as ProtoDebugReportMessage
+import com.buzbuz.smartautoclicker.core.smart.debugging.ConditionProfileMessage as ProtoConditionProfileMessage
+
+internal fun List<ConditionProfile>.toProtobuf(): ProtoDebugReportMessage =
+    debugReportMessage {
+        conditionProfileMessage = conditionProfileMessage {
+            entries.addAll(this@toProtobuf.map { profile ->
+                conditionProfileEntry {
+                    conditionId = profile.conditionId
+                    checkCount = profile.checkCount
+                    fulfilledCount = profile.fulfilledCount
+                    totalDurationNs = profile.totalDurationNs
+                    minDurationNs = profile.minDurationNs
+                    maxDurationNs = profile.maxDurationNs
+                }
+            })
+        }
+    }
+
+internal fun ProtoConditionProfileMessage.toDomain(): List<ConditionProfile> =
+    entriesList.map { entry ->
+        ConditionProfile(
+            conditionId = entry.conditionId,
+            checkCount = entry.checkCount,
+            fulfilledCount = entry.fulfilledCount,
+            totalDurationNs = entry.totalDurationNs,
+            minDurationNs = entry.minDurationNs,
+            maxDurationNs = entry.maxDurationNs,
+        )
+    }

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/DebugReportEventOccurrenceMapping.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/DebugReportEventOccurrenceMapping.kt
@@ -98,6 +98,7 @@ internal fun ProtoDebugReportMessage.toDomain(): DebugReportEventOccurrence? =
         ProtoDebugReportMessage.MessageTypeCase.TRIGGEREVENTMESSAGE ->
             triggerEventMessage.toDomain(relativeTimestampMs)
         ProtoDebugReportMessage.MessageTypeCase.COUNTERSINITMESSAGE -> null
+        ProtoDebugReportMessage.MessageTypeCase.CONDITIONPROFILEMESSAGE -> null
         ProtoDebugReportMessage.MessageTypeCase.MESSAGETYPE_NOT_SET -> {
             Log.e(LOG_TAG, "Can't read DebugReportEventOccurrence from protobuf")
             null

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/DebugReportOverviewMapping.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/DebugReportOverviewMapping.kt
@@ -19,6 +19,7 @@ package com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping
 import com.buzbuz.smartautoclicker.core.smart.debugging.debugReportOverview
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportOverview
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
 
 import com.buzbuz.smartautoclicker.core.smart.debugging.DebugReportOverview as ProtoDebugReportOverview
 
@@ -32,6 +33,8 @@ internal fun DebugReportOverview.toProtobuf(): ProtoDebugReportOverview =
         imageEventFulfilledCount = this@toProtobuf.imageEventFulfilledCount
         triggerEventFulfilledCount = this@toProtobuf.triggerEventFulfilledCount
         countersName.addAll(this@toProtobuf.counterNames)
+        activeDetectionDurationNs = this@toProtobuf.activeDetectionDuration.inWholeNanoseconds
+        executionLimiterWaitDurationNs = this@toProtobuf.executionLimiterWaitDuration.inWholeNanoseconds
     }
 
 internal fun ProtoDebugReportOverview.toDomain(): DebugReportOverview =
@@ -43,4 +46,6 @@ internal fun ProtoDebugReportOverview.toDomain(): DebugReportOverview =
         imageEventFulfilledCount = imageEventFulfilledCount,
         triggerEventFulfilledCount = triggerEventFulfilledCount,
         counterNames = countersNameList.toSet(),
+        activeDetectionDuration = activeDetectionDurationNs.nanoseconds,
+        executionLimiterWaitDuration = executionLimiterWaitDurationNs.nanoseconds,
     )

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/di/Hilt.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/di/Hilt.kt
@@ -17,6 +17,7 @@
 package com.buzbuz.smartautoclicker.core.smart.debugging.di
 
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.DebuggingRepository
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.DebuggingRepositoryImpl
 import com.buzbuz.smartautoclicker.core.smart.debugging.engine.DebugEngine
@@ -39,5 +40,10 @@ object SmartDebuggingModule {
     @Provides
     @Singleton
     internal fun providesDebuggingListener(debugEngine: DebugEngine): SmartProcessingListener =
+        debugEngine
+
+    @Provides
+    @Singleton
+    internal fun providesDebugReportTimingListener(debugEngine: DebugEngine): DebugReportTimingListener =
         debugEngine
 }

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/DebuggingRepository.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/DebuggingRepository.kt
@@ -20,6 +20,7 @@ import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.live.DebugL
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportCounterInitialValue
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportEventOccurrence
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportOverview
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -52,4 +53,7 @@ interface DebuggingRepository {
 
     /** Read the last detection session events occurrences. List will be empty no rapport is available. */
     fun getLastReportEventsOccurrences(): Flow<List<DebugReportEventOccurrence>?>
+
+    /** Read aggregate condition timings from the last detection session report. */
+    fun getLastReportConditionProfiles(): Flow<List<ConditionProfile>?>
 }

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/DebuggingRepositoryImpl.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/DebuggingRepositoryImpl.kt
@@ -24,6 +24,7 @@ import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.live.DebugL
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportCounterInitialValue
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportEventOccurrence
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportOverview
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
 import com.buzbuz.smartautoclicker.core.smart.debugging.engine.DebugEngine
 
 import kotlinx.coroutines.CoroutineDispatcher
@@ -94,5 +95,10 @@ internal class DebuggingRepositoryImpl @Inject constructor(
     override fun getLastReportEventsOccurrences(): Flow<List<DebugReportEventOccurrence>?> =
         flow {
             emit(debugReportDataSource.readMessages())
+        }.flowOn(ioDispatcher)
+
+    override fun getLastReportConditionProfiles(): Flow<List<ConditionProfile>?> =
+        flow {
+            emit(debugReportDataSource.readConditionProfile())
         }.flowOn(ioDispatcher)
 }

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/model/report/ConditionProfile.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/model/report/ConditionProfile.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report
+
+/** Aggregate timing statistics for one condition during a detection session. */
+data class ConditionProfile(
+    val conditionId: Long,
+    val checkCount: Long,
+    val fulfilledCount: Long,
+    val totalDurationNs: Long,
+    val minDurationNs: Long,
+    val maxDurationNs: Long,
+)

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/model/report/DebugReportOverview.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/domain/model/report/DebugReportOverview.kt
@@ -27,6 +27,8 @@ import kotlin.time.Duration
  * @param imageEventFulfilledCount The number of image events that have been triggered during the session.
  * @param triggerEventFulfilledCount The number of image events that have been triggered during the session.
  * @param counterNames The names of all counters available in the scenario that was ran to made this report.
+ * @param activeDetectionDuration Time spent actively processing scenario loops.
+ * @param executionLimiterWaitDuration Time spent suspended by the user-configured Execution Limiter.
  */
 data class DebugReportOverview(
     val scenarioId: Long,
@@ -36,4 +38,6 @@ data class DebugReportOverview(
     val imageEventFulfilledCount: Int,
     val triggerEventFulfilledCount: Int,
     val counterNames: Set<String>,
+    val activeDetectionDuration: Duration = Duration.ZERO,
+    val executionLimiterWaitDuration: Duration = Duration.ZERO,
 )

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/DebugEngine.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/DebugEngine.kt
@@ -22,6 +22,7 @@ import android.util.Size
 import com.buzbuz.smartautoclicker.core.base.di.Dispatcher
 import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.IO
 import com.buzbuz.smartautoclicker.core.domain.model.condition.ScreenCondition
+import com.buzbuz.smartautoclicker.core.domain.model.condition.Condition
 import com.buzbuz.smartautoclicker.core.domain.model.counter.Counter
 import com.buzbuz.smartautoclicker.core.domain.model.event.Event
 import com.buzbuz.smartautoclicker.core.domain.model.event.ScreenEvent
@@ -29,6 +30,7 @@ import com.buzbuz.smartautoclicker.core.domain.model.event.TriggerEvent
 import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.core.processing.domain.EventType
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 import com.buzbuz.smartautoclicker.core.processing.domain.model.ProcessedConditionResult
 import com.buzbuz.smartautoclicker.core.smart.debugging.data.DebugReportLocalDataSource
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.live.DebugLiveEventConditionResult
@@ -42,6 +44,9 @@ import com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder.EventOcc
 import com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder.EventStateRecorder
 import com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping.toCountersInitProtobuf
 import com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder.ScreenConditionOccurrenceRecorder
+import com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder.ConditionProfileRecorder
+import com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder.ProcessingTimingRecorder
+import com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping.toProtobuf
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -56,6 +61,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.collections.toList
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
 
 
 /** Engine for the debugging of a scenario processing. */
@@ -68,7 +74,9 @@ internal class DebugEngine @Inject constructor(
     private val screenConditionOccurrenceRecorder: ScreenConditionOccurrenceRecorder,
     private val counterValuesRecorder: CounterValuesRecorder,
     private val eventStateRecorder: EventStateRecorder,
-) : SmartProcessingListener {
+    private val conditionProfileRecorder: ConditionProfileRecorder,
+    private val processingTimingRecorder: ProcessingTimingRecorder,
+) : SmartProcessingListener, DebugReportTimingListener {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val coroutineScopeIo: CoroutineScope =
@@ -92,13 +100,21 @@ internal class DebugEngine @Inject constructor(
         counters: List<Counter>,
         generateLiveEvents: Boolean,
         generateReport: Boolean,
+        conditions: List<Condition>,
     ) {
+        isReportEnabled = generateReport
+        if (generateReport) {
+            conditionProfileRecorder.start(conditions.map { it.getValidId() }.toLongArray())
+        } else {
+            conditionProfileRecorder.reset()
+        }
+        processingTimingRecorder.reset()
+
         coroutineScopeIo.launch {
-            isReportEnabled = generateReport
             shouldGenerateLiveEvents = generateLiveEvents
             _isDebuggingSession.value = true
 
-            if (shouldWriteReport) {
+            if (generateReport) {
                 overviewRecorder.onSessionStart(scenario)
                 counterValuesRecorder.onSessionStarted(counters)
 
@@ -108,22 +124,36 @@ internal class DebugEngine @Inject constructor(
         }
     }
 
+    override fun onConditionChecked(conditionId: Long, durationNs: Long, fulfilled: Boolean) {
+        if (isReportEnabled) {
+            conditionProfileRecorder.record(conditionId, durationNs, fulfilled)
+        }
+    }
+
+    override fun onDetectionLoopProcessed(durationNs: Long) {
+        if (isReportEnabled) processingTimingRecorder.recordDetectionLoop(durationNs)
+    }
+
+    override fun onExecutionLimiterWaited(durationNs: Long) {
+        if (isReportEnabled) processingTimingRecorder.recordExecutionLimiterWait(durationNs)
+    }
+
     // Processing started on current frame
     override fun onEventsListProcessingStarted(eventType: EventType) {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
-
             overviewRecorder.onFrameProcessingStarted()
         }
     }
 
     // Processing started for current Event
     override fun onEventProcessingStarted(event: Event) {
+        val writeReport = shouldWriteReport
         coroutineScopeIo.launch {
             eventOccurrencesRecorder.onEventProcessingStarted()
             screenConditionOccurrenceRecorder.onEventProcessingStarted()
 
-            if (!shouldWriteReport) return@launch
+            if (!writeReport) return@launch
             counterValuesRecorder.onEventProcessingStarted()
             eventStateRecorder.onEventProcessingStarted()
         }
@@ -154,9 +184,8 @@ internal class DebugEngine @Inject constructor(
 
     // Processing ended for current Event
     override fun onEventActionsExecuted(event: Event, results: List<ProcessedConditionResult>) {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
-
             overviewRecorder.onActionsExecuted(event)
 
             @Suppress("UNCHECKED_CAST")
@@ -174,17 +203,15 @@ internal class DebugEngine @Inject constructor(
 
     // Processing ended on current frame
     override fun onEventsProcessingCompleted(eventType: EventType) {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
-
             overviewRecorder.onFrameProcessingStopped()
         }
     }
 
     override fun onEventsProcessingCancelled() {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
-
             overviewRecorder.onFrameProcessingStopped()
             screenConditionOccurrenceRecorder.reset()
             eventOccurrencesRecorder.reset()
@@ -193,39 +220,48 @@ internal class DebugEngine @Inject constructor(
 
     // Image Condition is processed
     override fun onScreenConditionProcessingStarted() {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
-
             screenConditionOccurrenceRecorder.onImageConditionProcessingStarted()
         }
     }
 
     // Called anyway,even if not matched
     override fun onScreenConditionProcessingCompleted(result: ProcessedConditionResult.Screen) {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
-
             screenConditionOccurrenceRecorder.onImageConditionProcessingCompleted(result)
         }
     }
 
     override fun onCounterValueChanged(counterName: String, previousValue: Double, newValue: Double) {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
             counterValuesRecorder.onCounterValueChanged(counterName, previousValue, newValue)
         }
     }
 
     override fun onEventStateChanged(event: Event, newValue: Boolean) {
+        if (!shouldWriteReport) return
         coroutineScopeIo.launch {
-            if (!shouldWriteReport) return@launch
             eventStateRecorder.onEventStateChanged(event, newValue)
         }
     }
 
     override fun onSessionEnded() {
+        val writeReport = isReportEnabled
+        val conditionProfile = if (writeReport) conditionProfileRecorder.snapshot() else emptyList()
+        val activeDetectionDurationNs = processingTimingRecorder.activeDetectionDurationNs
+        val executionLimiterWaitDurationNs = processingTimingRecorder.executionLimiterWaitDurationNs
+        conditionProfileRecorder.reset()
+        processingTimingRecorder.reset()
+
         coroutineScopeIo.launch {
-            if (shouldWriteReport) {
+            if (conditionProfile.isNotEmpty()) {
+                debugReportLocalDataSource.writeMessageToReport(conditionProfile.toProtobuf())
+            }
+
+            if (writeReport) {
                 debugReportLocalDataSource.stopReportWrite(
                     overview = DebugReportOverview(
                         scenarioId = overviewRecorder.scenarioId,
@@ -235,6 +271,8 @@ internal class DebugEngine @Inject constructor(
                         imageEventFulfilledCount = overviewRecorder.imageEventFulfilledCount,
                         triggerEventFulfilledCount = overviewRecorder.triggerEventFulfilledCount,
                         counterNames = counterValuesRecorder.counterNames,
+                        activeDetectionDuration = activeDetectionDurationNs.nanoseconds,
+                        executionLimiterWaitDuration = executionLimiterWaitDurationNs.nanoseconds,
                     )
                 )
 
@@ -247,9 +285,9 @@ internal class DebugEngine @Inject constructor(
             screenConditionOccurrenceRecorder.reset()
             _lastEventProcessed.value = null
             _isDebuggingSession.value = false
-            isReportEnabled = false
             shouldGenerateLiveEvents = false
         }
+        isReportEnabled = false
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ConditionProfileRecorder.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ConditionProfileRecorder.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder
+
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
+import javax.inject.Inject
+
+/** Fixed-size, allocation-free-on-record aggregate condition profiler. */
+internal class ConditionProfileRecorder @Inject constructor() {
+
+    private var conditionIds = LongArray(0)
+    private var checkCounts = LongArray(0)
+    private var fulfilledCounts = LongArray(0)
+    private var totalDurationsNs = LongArray(0)
+    private var minDurationsNs = LongArray(0)
+    private var maxDurationsNs = LongArray(0)
+
+    fun start(conditionIds: LongArray) {
+        this.conditionIds = conditionIds.distinct().sorted().toLongArray()
+        checkCounts = LongArray(this.conditionIds.size)
+        fulfilledCounts = LongArray(this.conditionIds.size)
+        totalDurationsNs = LongArray(this.conditionIds.size)
+        minDurationsNs = LongArray(this.conditionIds.size) { Long.MAX_VALUE }
+        maxDurationsNs = LongArray(this.conditionIds.size)
+    }
+
+    fun record(conditionId: Long, durationNs: Long, fulfilled: Boolean) {
+        val index = conditionIds.binarySearch(conditionId)
+        if (index < 0) return
+        checkCounts[index] += 1
+        if (fulfilled) fulfilledCounts[index] += 1
+        totalDurationsNs[index] += durationNs
+        if (durationNs < minDurationsNs[index]) minDurationsNs[index] = durationNs
+        if (durationNs > maxDurationsNs[index]) maxDurationsNs[index] = durationNs
+    }
+
+    fun snapshot(): List<ConditionProfile> =
+        buildList(conditionIds.size) {
+            for (index in conditionIds.indices) {
+                add(
+                    ConditionProfile(
+                        conditionId = conditionIds[index],
+                        checkCount = checkCounts[index],
+                        fulfilledCount = fulfilledCounts[index],
+                        totalDurationNs = totalDurationsNs[index],
+                        minDurationNs = minDurationsNs[index].takeUnless { it == Long.MAX_VALUE } ?: 0L,
+                        maxDurationNs = maxDurationsNs[index],
+                    )
+                )
+            }
+        }
+
+    fun reset() {
+        conditionIds = LongArray(0)
+        checkCounts = LongArray(0)
+        fulfilledCounts = LongArray(0)
+        totalDurationsNs = LongArray(0)
+        minDurationsNs = LongArray(0)
+        maxDurationsNs = LongArray(0)
+    }
+}

--- a/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ProcessingTimingRecorder.kt
+++ b/core/smart/debugging/src/main/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ProcessingTimingRecorder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder
+
+import javax.inject.Inject
+
+/** Fixed-size aggregate for processing-loop measurements included in the Debug Report overview. */
+internal class ProcessingTimingRecorder @Inject constructor() {
+
+    var activeDetectionDurationNs: Long = 0L
+        private set
+    var executionLimiterWaitDurationNs: Long = 0L
+        private set
+
+    fun recordDetectionLoop(durationNs: Long) {
+        activeDetectionDurationNs += durationNs
+    }
+
+    fun recordExecutionLimiterWait(durationNs: Long) {
+        executionLimiterWaitDurationNs += durationNs
+    }
+
+    fun reset() {
+        activeDetectionDurationNs = 0L
+        executionLimiterWaitDurationNs = 0L
+    }
+}

--- a/core/smart/debugging/src/main/proto/ConditionProfileMessage.proto
+++ b/core/smart/debugging/src/main/proto/ConditionProfileMessage.proto
@@ -1,0 +1,19 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+syntax = "proto3";
+option java_multiple_files = true;
+
+package com.buzbuz.smartautoclicker.core.smart.debugging;
+
+/** Aggregate condition timings collected during one detection session. */
+message ConditionProfileMessage {
+    repeated ConditionProfileEntry entries = 1;
+
+    message ConditionProfileEntry {
+        int64 conditionId = 1;
+        int64 checkCount = 2;
+        int64 fulfilledCount = 3;
+        int64 totalDurationNs = 4;
+        int64 minDurationNs = 5;
+        int64 maxDurationNs = 6;
+    }
+}

--- a/core/smart/debugging/src/main/proto/DebugReportMessage.proto
+++ b/core/smart/debugging/src/main/proto/DebugReportMessage.proto
@@ -22,6 +22,7 @@ package com.buzbuz.smartautoclicker.core.smart.debugging;
 import "CountersInitMessage.proto";
 import "ImageEventMessage.proto";
 import "TriggerEventMessage.proto";
+import "ConditionProfileMessage.proto";
 
 /** Base class for debug report messages abstraction. */
 message DebugReportMessage {
@@ -40,5 +41,8 @@ message DebugReportMessage {
 
         /** Initial value for counters. */
         CountersInitMessage countersInitMessage = 4;
+
+        /** Aggregate per-condition timing profile, written once when the session ends. */
+        ConditionProfileMessage conditionProfileMessage = 5;
     }
 }

--- a/core/smart/debugging/src/main/proto/DebugReportOverview.proto
+++ b/core/smart/debugging/src/main/proto/DebugReportOverview.proto
@@ -42,4 +42,10 @@ message DebugReportOverview {
 
     /** The list of counter name for this scenario. */
     repeated string countersName = 7;
+
+    /** Time spent actively processing scenario loops, excluding the post-loop Execution Limiter delay. */
+    int64 activeDetectionDurationNs = 8;
+
+    /** Elapsed suspension caused specifically by the user-configured Execution Limiter. */
+    int64 executionLimiterWaitDurationNs = 9;
 }

--- a/core/smart/debugging/src/test/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/PerformanceTimingMappingTests.kt
+++ b/core/smart/debugging/src/test/java/com/buzbuz/smartautoclicker/core/smart/debugging/data/mapping/PerformanceTimingMappingTests.kt
@@ -1,0 +1,61 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.core.smart.debugging.data.mapping
+
+import com.buzbuz.smartautoclicker.core.smart.debugging.debugReportOverview
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportOverview
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+
+class PerformanceTimingMappingTests {
+
+    @Test
+    fun `condition profile survives protobuf mapping`() {
+        val expected = listOf(
+            ConditionProfile(
+                conditionId = 42L,
+                checkCount = 10L,
+                fulfilledCount = 3L,
+                totalDurationNs = 1_000L,
+                minDurationNs = 25L,
+                maxDurationNs = 300L,
+            )
+        )
+
+        val actual = expected.toProtobuf().conditionProfileMessage.toDomain()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `overview performance durations survive protobuf mapping`() {
+        val expected = DebugReportOverview(
+            scenarioId = 7L,
+            duration = 12_000.milliseconds,
+            frameCount = 50L,
+            averageFrameProcessingDuration = 4.milliseconds,
+            imageEventFulfilledCount = 2,
+            triggerEventFulfilledCount = 1,
+            counterNames = setOf("counter"),
+            activeDetectionDuration = 987_654_321.nanoseconds,
+            executionLimiterWaitDuration = 123_456_789.nanoseconds,
+        )
+
+        assertEquals(expected, expected.toProtobuf().toDomain())
+    }
+
+    @Test
+    fun `older overview without performance fields maps them to zero`() {
+        val oldOverview = debugReportOverview {
+            scenarioId = 7L
+            durationMs = 1_000L
+        }
+
+        val mapped = oldOverview.toDomain()
+
+        assertEquals(0.nanoseconds, mapped.activeDetectionDuration)
+        assertEquals(0.nanoseconds, mapped.executionLimiterWaitDuration)
+    }
+}

--- a/core/smart/debugging/src/test/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ConditionProfileRecorderTests.kt
+++ b/core/smart/debugging/src/test/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ConditionProfileRecorderTests.kt
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConditionProfileRecorderTests {
+
+    @Test
+    fun `record aggregates count outcomes and durations`() {
+        val recorder = ConditionProfileRecorder()
+        recorder.start(longArrayOf(42L, 7L, 42L))
+
+        recorder.record(conditionId = 42L, durationNs = 100L, fulfilled = false)
+        recorder.record(conditionId = 42L, durationNs = 300L, fulfilled = true)
+        recorder.record(conditionId = 7L, durationNs = 50L, fulfilled = true)
+        recorder.record(conditionId = 999L, durationNs = 1L, fulfilled = true)
+
+        val profiles = recorder.snapshot()
+        assertEquals(listOf(7L, 42L), profiles.map { it.conditionId })
+
+        with(profiles.first { it.conditionId == 42L }) {
+            assertEquals(2L, checkCount)
+            assertEquals(1L, fulfilledCount)
+            assertEquals(400L, totalDurationNs)
+            assertEquals(100L, minDurationNs)
+            assertEquals(300L, maxDurationNs)
+        }
+    }
+
+    @Test
+    fun `snapshot includes unchecked conditions with zero durations`() {
+        val recorder = ConditionProfileRecorder()
+        recorder.start(longArrayOf(5L))
+
+        val profile = recorder.snapshot().single()
+        assertEquals(0L, profile.checkCount)
+        assertEquals(0L, profile.minDurationNs)
+        assertEquals(0L, profile.maxDurationNs)
+    }
+
+    @Test
+    fun `starting a new session discards the previous session`() {
+        val recorder = ConditionProfileRecorder()
+        recorder.start(longArrayOf(1L))
+        recorder.record(conditionId = 1L, durationNs = 100L, fulfilled = true)
+
+        recorder.start(longArrayOf(2L))
+        recorder.record(conditionId = 2L, durationNs = 25L, fulfilled = false)
+
+        val profile = recorder.snapshot().single()
+        assertEquals(2L, profile.conditionId)
+        assertEquals(1L, profile.checkCount)
+        assertEquals(25L, profile.totalDurationNs)
+    }
+}

--- a/core/smart/debugging/src/test/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ProcessingTimingRecorderTests.kt
+++ b/core/smart/debugging/src/test/java/com/buzbuz/smartautoclicker/core/smart/debugging/engine/recorder/ProcessingTimingRecorderTests.kt
@@ -1,0 +1,25 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.core.smart.debugging.engine.recorder
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProcessingTimingRecorderTests {
+
+    @Test
+    fun `processing and limiter durations remain separate and reset together`() {
+        val recorder = ProcessingTimingRecorder()
+
+        recorder.recordDetectionLoop(100L)
+        recorder.recordDetectionLoop(250L)
+        recorder.recordExecutionLimiterWait(75L)
+
+        assertEquals(350L, recorder.activeDetectionDurationNs)
+        assertEquals(75L, recorder.executionLimiterWaitDurationNs)
+
+        recorder.reset()
+
+        assertEquals(0L, recorder.activeDetectionDurationNs)
+        assertEquals(0L, recorder.executionLimiterWaitDurationNs)
+    }
+}

--- a/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/DetectorEngine.kt
+++ b/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/DetectorEngine.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.media.Image
 import android.media.projection.MediaProjectionManager
+import android.os.SystemClock
 import android.util.Log
 
 import com.buzbuz.smartautoclicker.code.smart.detectionmodels.text.OCRModelsRepository
@@ -44,6 +45,7 @@ import com.buzbuz.smartautoclicker.core.processing.data.processor.ScenarioProces
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScalingManager
 import com.buzbuz.smartautoclicker.core.settings.domain.SettingsRepository
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -81,6 +83,7 @@ class DetectorEngine @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val appComponentsProvider: AppComponentsProvider,
     private val debuggingListener: SmartProcessingListener,
+    private val debugReportTimingListener: DebugReportTimingListener,
     private val ocrModelsRepository: OCRModelsRepository,
 ) {
 
@@ -114,6 +117,10 @@ class DetectorEngine @Inject constructor(
 
     /** Scenario currently processed. Null if not detecting. */
     private var minProcessingDurationNs: Long = DEFAULT_MIN_PROCESSING_DURATION_NS
+    /** Report timing receiver for the current detection session, or null when report generation is disabled. */
+    private var activeDebugReportTimingListener: DebugReportTimingListener? = null
+    /** True only for the user-configured rate limit; the unlimited-mode safety delay is not reported as limiter time. */
+    private var isExecutionLimiterEnabled: Boolean = false
 
     /**
      * Start the screen detection.
@@ -234,6 +241,7 @@ class DetectorEngine @Inject constructor(
 
             // Compute minimal processing duration
             val frameLimit = scenario.computeRate
+            isExecutionLimiterEnabled = frameLimit > 0.0
             minProcessingDurationNs =
                 if (frameLimit <= 0.0) DEFAULT_MIN_PROCESSING_DURATION_NS
                 else (ONE_SECOND_IN_NANO / frameLimit).toLong()
@@ -248,8 +256,10 @@ class DetectorEngine @Inject constructor(
                     counters = counters,
                     generateLiveEvents = liveDebugging,
                     generateReport = generateReport,
+                    conditions = screenEvents.flatMap { it.conditions } + triggerEvents.flatMap { it.conditions },
                 )
             }
+            activeDebugReportTimingListener = debugReportTimingListener.takeIf { generateReport }
 
             // Instantiate the processor and initialize its detection state.
             scenarioProcessor = ScenarioProcessor(
@@ -264,7 +274,8 @@ class DetectorEngine @Inject constructor(
                 androidExecutor = actionExecutor,
                 unblockWorkaroundEnabled = settingsRepository.isInputBlockWorkaroundEnabled(),
                 onStopRequested = { stopDetection() },
-                progressListener  = if (liveDebugging || generateReport) debuggingListener else null,
+                progressListener = if (liveDebugging || generateReport) debuggingListener else null,
+                debugReportTimingListener = activeDebugReportTimingListener,
             )
             scenarioProcessor?.onScenarioStart(context)
 
@@ -329,6 +340,7 @@ class DetectorEngine @Inject constructor(
             scenarioProcessor?.onScenarioEnd()
             scenarioProcessor = null
             debuggingListener.onSessionEnded()
+            activeDebugReportTimingListener = null
 
             scalingManager.stopScaling()
             displayRecorder.resizeDisplay(displayConfigManager.displayConfig.sizePx)
@@ -336,6 +348,7 @@ class DetectorEngine @Inject constructor(
             _state.emit(DetectorState.RECORDING)
             processingShutdownJob = null
             minProcessingDurationNs  = DEFAULT_MIN_PROCESSING_DURATION_NS
+            isExecutionLimiterEnabled = false
         }
     }
 
@@ -380,13 +393,19 @@ class DetectorEngine @Inject constructor(
                 processingDurationNs = measureNanoTime {
                     scenarioProcessor?.process(screenFrame)
                 }
+                activeDebugReportTimingListener?.onDetectionLoopProcessed(processingDurationNs)
 
                 // Avoid looping infinitely to quickly for nothing.
                 if (processingDurationNs < minProcessingDurationNs) {
-                    delay(duration = max(
+                    val limiterDelayMs = max(
                         a = 1,
                         b = (minProcessingDurationNs - processingDurationNs) / ONE_MILLISECOND_IN_NANO,
-                    ).milliseconds)
+                    )
+                    delayProcessingLoop(
+                        delayMs = limiterDelayMs,
+                        timingListener = activeDebugReportTimingListener,
+                        isExecutionLimiterEnabled = isExecutionLimiterEnabled,
+                    )
                 }
 
             } ?: delay(NO_IMAGE_DELAY_MS.milliseconds)
@@ -420,6 +439,27 @@ class DetectorEngine @Inject constructor(
         }
 
         return loadTextDetectionModels(ocrDetectModelPath, ocrRecoModels)
+    }
+}
+
+/** Wait between processing loops and report only delays caused by the user-configured Execution Limiter. */
+internal suspend fun delayProcessingLoop(
+    delayMs: Long,
+    timingListener: DebugReportTimingListener?,
+    isExecutionLimiterEnabled: Boolean,
+    elapsedRealtimeNanos: () -> Long = SystemClock::elapsedRealtimeNanos,
+    delayBlock: suspend (Long) -> Unit = { durationMs -> delay(durationMs.milliseconds) },
+) {
+    if (timingListener == null || !isExecutionLimiterEnabled) {
+        delayBlock(delayMs)
+        return
+    }
+
+    val startTimestampNs = elapsedRealtimeNanos()
+    try {
+        delayBlock(delayMs)
+    } finally {
+        timingListener.onExecutionLimiterWaited(elapsedRealtimeNanos() - startTimestampNs)
     }
 }
 

--- a/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/processor/ConditionsVerifier.kt
+++ b/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/processor/ConditionsVerifier.kt
@@ -17,6 +17,7 @@
 package com.buzbuz.smartautoclicker.core.processing.data.processor
 
 import android.graphics.Bitmap
+import android.os.SystemClock
 
 import com.buzbuz.smartautoclicker.core.detection.ImageDetector
 import com.buzbuz.smartautoclicker.core.detection.NumberFormatType as DetectionNumberFormatType
@@ -33,6 +34,7 @@ import com.buzbuz.smartautoclicker.core.processing.data.processor.state.Processi
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScalingManager
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScreenConditionScalingInfo
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 import com.buzbuz.smartautoclicker.core.processing.domain.model.ProcessedConditionResult
 
 import kotlinx.coroutines.yield
@@ -47,6 +49,7 @@ internal class ConditionsVerifier(
     private val scalingManager: ScalingManager,
     private val bitmapSupplier: suspend (String, Int, Int) -> Bitmap?,
     private val progressListener: SmartProcessingListener? = null,
+    private val debugReportTimingListener: DebugReportTimingListener? = null,
 ) {
 
     /** List of results for the last call to verifyConditions. */
@@ -64,7 +67,16 @@ internal class ConditionsVerifier(
 
         var verificationResult: ProcessedConditionResult
         for (condition in conditions) {
-            verificationResult = verifyCondition(condition)
+            verificationResult = debugReportTimingListener?.let { timingListener ->
+                val startTimestampNs = SystemClock.elapsedRealtimeNanos()
+                val result = verifyCondition(condition)
+                timingListener.onConditionChecked(
+                    conditionId = condition.getValidId(),
+                    durationNs = SystemClock.elapsedRealtimeNanos() - startTimestampNs,
+                    fulfilled = result.isFulfilled,
+                )
+                result
+            } ?: verifyCondition(condition)
             verificationResults.addResult(condition.getValidId(), verificationResult)
 
             if (operator == OR && verificationResult.isFulfilled) {

--- a/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/processor/ScenarioProcessor.kt
+++ b/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/data/processor/ScenarioProcessor.kt
@@ -29,6 +29,7 @@ import com.buzbuz.smartautoclicker.core.processing.data.processor.state.Processi
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScalingManager
 import com.buzbuz.smartautoclicker.core.processing.domain.EventType
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 
 import kotlinx.coroutines.yield
 
@@ -56,6 +57,7 @@ internal class ScenarioProcessor(
     unblockWorkaroundEnabled: Boolean = false,
     private val onStopRequested: () -> Unit,
     private val progressListener: SmartProcessingListener?,
+    private val debugReportTimingListener: DebugReportTimingListener? = null,
 ) {
 
     /** Handle the processing state of the scenario. */
@@ -72,6 +74,7 @@ internal class ScenarioProcessor(
         scalingManager = scalingManager,
         bitmapSupplier = bitmapSupplier,
         progressListener = progressListener,
+        debugReportTimingListener = debugReportTimingListener,
     )
     /** Execute the detected event actions. */
     private val actionExecutor = ActionExecutor(

--- a/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/domain/DebugReportTimingListener.kt
+++ b/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/domain/DebugReportTimingListener.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.buzbuz.smartautoclicker.core.processing.domain
+
+/** Receives synchronous performance measurements for the Debug Report. */
+interface DebugReportTimingListener {
+
+    /** Record one completed condition check. Implementations must not allocate per call. */
+    fun onConditionChecked(conditionId: Long, durationNs: Long, fulfilled: Boolean)
+
+    /** Record one completed call to the active scenario processing loop. */
+    fun onDetectionLoopProcessed(durationNs: Long)
+
+    /** Record elapsed suspension caused specifically by the user-configured Execution Limiter. */
+    fun onExecutionLimiterWaited(durationNs: Long)
+}

--- a/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/domain/SmartProcessingListener.kt
+++ b/core/smart/processing/src/main/java/com/buzbuz/smartautoclicker/core/processing/domain/SmartProcessingListener.kt
@@ -17,6 +17,7 @@
 package com.buzbuz.smartautoclicker.core.processing.domain
 
 import com.buzbuz.smartautoclicker.core.domain.model.condition.ScreenCondition
+import com.buzbuz.smartautoclicker.core.domain.model.condition.Condition
 import com.buzbuz.smartautoclicker.core.domain.model.counter.Counter
 import com.buzbuz.smartautoclicker.core.domain.model.event.Event
 import com.buzbuz.smartautoclicker.core.domain.model.event.ScreenEvent
@@ -34,12 +35,14 @@ interface SmartProcessingListener {
      * @param counters the list of [Counter] to be processed for this scenario.
      * @param generateLiveEvents tells if the live debugging events should be generated.
      * @param generateReport tells if the debug report should be generated.
+     * @param conditions all conditions in this session, used to allocate fixed report storage before processing.
      */
     fun onSessionStarted(
         scenario: Scenario,
         counters: List<Counter>,
         generateLiveEvents: Boolean,
         generateReport: Boolean,
+        conditions: List<Condition>,
     ) = Unit
 
 

--- a/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/DetectorEngineDetectionOrientationTests.kt
+++ b/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/DetectorEngineDetectionOrientationTests.kt
@@ -39,6 +39,7 @@ import com.buzbuz.smartautoclicker.core.processing.data.DetectorEngine
 import com.buzbuz.smartautoclicker.core.processing.data.DetectorState
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScalingManager
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 import com.buzbuz.smartautoclicker.core.settings.domain.SettingsRepository
 
 import io.mockk.MockKAnnotations
@@ -107,6 +108,7 @@ class DetectorEngineDetectionOrientationTests {
     @RelaxedMockK private lateinit var mockSettingsRepository: SettingsRepository
     @RelaxedMockK private lateinit var mockAppComponentsProvider: AppComponentsProvider
     @RelaxedMockK private lateinit var mockDebuggingListener: SmartProcessingListener
+    @RelaxedMockK private lateinit var mockDebugReportTimingListener: DebugReportTimingListener
     @RelaxedMockK private lateinit var mockOcrModelsRepository: OCRModelsRepository
     @RelaxedMockK private lateinit var mockImageDetector: ImageDetector
     @RelaxedMockK private lateinit var mockContext: Context
@@ -245,6 +247,7 @@ class DetectorEngineDetectionOrientationTests {
             settingsRepository = mockSettingsRepository,
             appComponentsProvider = mockAppComponentsProvider,
             debuggingListener = mockDebuggingListener,
+            debugReportTimingListener = mockDebugReportTimingListener,
             ocrModelsRepository = mockOcrModelsRepository,
         )
 

--- a/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/DetectorEngineOrientationTests.kt
+++ b/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/DetectorEngineOrientationTests.kt
@@ -33,6 +33,7 @@ import com.buzbuz.smartautoclicker.core.display.recorder.DisplayRecorder
 import com.buzbuz.smartautoclicker.core.processing.data.DetectorEngine
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScalingManager
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 import com.buzbuz.smartautoclicker.core.settings.domain.SettingsRepository
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -82,6 +83,7 @@ class DetectorEngineOrientationTests {
     @Mock private lateinit var mockSettingsRepository: SettingsRepository
     @Mock private lateinit var mockAppComponentsProvider: AppComponentsProvider
     @Mock private lateinit var mockDebuggingListener: SmartProcessingListener
+    @Mock private lateinit var mockDebugReportTimingListener: DebugReportTimingListener
     @Mock private lateinit var mockOcrModelsRepository: OCRModelsRepository
 
     private val mockContext: Context = mock(Context::class.java)
@@ -161,6 +163,7 @@ class DetectorEngineOrientationTests {
             settingsRepository = mockSettingsRepository,
             appComponentsProvider = mockAppComponentsProvider,
             debuggingListener = mockDebuggingListener,
+            debugReportTimingListener = mockDebugReportTimingListener,
             ocrModelsRepository = mockOcrModelsRepository,
         )
 

--- a/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/ExecutionLimiterTimingTests.kt
+++ b/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/ExecutionLimiterTimingTests.kt
@@ -1,0 +1,54 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.core.processing.tests
+
+import com.buzbuz.smartautoclicker.core.processing.data.delayProcessingLoop
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class ExecutionLimiterTimingTests {
+
+    @Test
+    fun `unlimited mode safety delay is not reported as limiter time`() = runTest {
+        val listener = mock<DebugReportTimingListener>()
+        var delayedMs = 0L
+
+        delayProcessingLoop(
+            delayMs = 1L,
+            timingListener = listener,
+            isExecutionLimiterEnabled = false,
+            elapsedRealtimeNanos = { error("Clock must not be read") },
+            delayBlock = { delayedMs = it },
+        )
+
+        assertEquals(1L, delayedMs)
+        verifyNoInteractions(listener)
+    }
+
+    @Test
+    fun `limiter records elapsed wait including partial wait on cancellation`() = runTest {
+        val listener = mock<DebugReportTimingListener>()
+        val timestamps = ArrayDeque(listOf(100L, 275L))
+
+        try {
+            delayProcessingLoop(
+                delayMs = 10L,
+                timingListener = listener,
+                isExecutionLimiterEnabled = true,
+                elapsedRealtimeNanos = { timestamps.removeFirst() },
+                delayBlock = { throw CancellationException("stop") },
+            )
+            fail("Expected limiter wait to be cancelled")
+        } catch (_: CancellationException) {
+            // Expected: the finally block must still retain the partial elapsed wait.
+        }
+
+        verify(listener).onExecutionLimiterWaited(175L)
+    }
+}

--- a/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/ScenarioProcessorTests.kt
+++ b/core/smart/processing/src/test/java/com/buzbuz/smartautoclicker/core/processing/tests/ScenarioProcessorTests.kt
@@ -41,6 +41,7 @@ import com.buzbuz.smartautoclicker.core.processing.data.processor.ScenarioProces
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScreenConditionScalingInfo
 import com.buzbuz.smartautoclicker.core.processing.data.scaling.ScalingManager
 import com.buzbuz.smartautoclicker.core.processing.domain.SmartProcessingListener
+import com.buzbuz.smartautoclicker.core.processing.domain.DebugReportTimingListener
 import com.buzbuz.smartautoclicker.core.processing.shadows.ShadowBitmapCreator
 import com.buzbuz.smartautoclicker.core.processing.utils.ProcessingData.newCondition
 import com.buzbuz.smartautoclicker.core.processing.utils.ProcessingData.newEvent
@@ -64,6 +65,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.argumentCaptor
@@ -121,6 +123,7 @@ class ScenarioProcessorTests {
     @Mock private lateinit var mockAndroidExecutor: AndroidActionExecutor
     @Mock private lateinit var mockEndListener: StopRequestListener
     @Mock private lateinit var mockProgressListener: SmartProcessingListener
+    @Mock private lateinit var mockDebugReportTimingListener: DebugReportTimingListener
 
     @Mock private lateinit var mockScreenBitmap: Bitmap
 
@@ -166,6 +169,7 @@ class ScenarioProcessorTests {
     private fun createNewScenarioProcessor(
         events: List<ScreenEvent>,
         triggerEvent: List<TriggerEvent>,
+        timingEnabled: Boolean = true,
     ) : ScenarioProcessor {
         val processor = ScenarioProcessor(
             processingTag = "",
@@ -179,6 +183,7 @@ class ScenarioProcessorTests {
             androidExecutor = mockAndroidExecutor,
             onStopRequested = mockEndListener::onStopRequested,
             progressListener = mockProgressListener,
+            debugReportTimingListener = mockDebugReportTimingListener.takeIf { timingEnabled },
         )
 
         Mockito.clearInvocations(mockAndroidExecutor)
@@ -245,11 +250,11 @@ class ScenarioProcessorTests {
             actions = listOf(newDefaultClickAction()),
         )
 
-        scenarioProcessor = createNewScenarioProcessor(listOf(event), emptyList())
+        scenarioProcessor = createNewScenarioProcessor(listOf(event), emptyList(), timingEnabled = false)
         scenarioProcessor.process(mockScreenBitmap)
 
         verify(mockImageDetector).setScreenBitmap(mockScreenBitmap, "")
-        verifyNoInteractions(mockAndroidExecutor, mockEndListener)
+        verifyNoInteractions(mockDebugReportTimingListener, mockAndroidExecutor, mockEndListener)
     }
 
     @Test
@@ -576,6 +581,7 @@ class ScenarioProcessorTests {
         scenarioProcessor.process(mockScreenBitmap)
 
         verify(mockImageDetector).setScreenBitmap(mockScreenBitmap, "")
+        verify(mockDebugReportTimingListener, times(2)).onConditionChecked(eq(1L), org.mockito.kotlin.any(), org.mockito.kotlin.any())
         verifyNoInteractions(mockAndroidExecutor, mockEndListener)
     }
 
@@ -866,6 +872,7 @@ class ScenarioProcessorTests {
         scenarioProcessor.process(mockScreenBitmap)
 
         verify(mockImageDetector).setScreenBitmap(mockScreenBitmap, "")
+        verify(mockDebugReportTimingListener, times(1)).onConditionChecked(eq(1L), org.mockito.kotlin.any(), org.mockito.kotlin.any())
         assertActionGesture(expectedDuration)
         verifyNoInteractions(mockEndListener)
     }

--- a/docs/debug-report-performance-benchmark.md
+++ b/docs/debug-report-performance-benchmark.md
@@ -1,0 +1,94 @@
+# Debug Report condition-timing benchmark
+
+## Purpose
+
+The condition-timing prototype was benchmarked before it was converted into the permanent Debug Report architecture.
+The goal was to determine whether two monotonic clock reads and one fixed-size aggregate update per reached condition
+created a measurable real-world cost.
+
+This was a device-level comparison rather than a synthetic microbenchmark. It includes the natural variance of screen
+capture, image detection, game rendering, Android scheduling, and temperature. The result can therefore show whether
+the added measurement stands out during real use; it cannot prove that its cost is exactly zero.
+
+## Test setup
+
+- Device: Xiaomi M2012K11I, Android 14, running on battery with its case removed.
+- Scenario: a real game automation performing six attack/battle/exit loops before stopping itself.
+- Execution Limiter: 10 loops per second for every run.
+- Runs: 20 valid runs, five for each mode.
+- Total measured detector runtime: 1,106.394 seconds.
+- Thermal control: the four modes used a balanced rotation rather than running one mode in a single block.
+- Rotation: `C A B D / A D C B / C B A D / B D A C / D B A C`.
+- Observations: detector elapsed time, process CPU ticks, battery level, battery temperature, Android thermal status,
+  report size, and condition-profile consistency.
+
+The modes were:
+
+| Mode | Existing Debug Report | Condition timing |
+|---|---:|---:|
+| A | Off | Off |
+| B | On | Off |
+| C | On | On |
+| D | Off | On |
+
+Modes A and D isolated the prototype recorder from the existing report machinery. Modes B and C measured its
+incremental cost when used as intended inside the Debug Report. The independent combinations existed only for the
+prototype experiment; the permanent implementation always enables condition timing with the Debug Report.
+
+## Results
+
+| Mode | Median elapsed | Range | Median CPU ticks | Median CPU ticks/s |
+|---|---:|---:|---:|---:|
+| A: neither | 54.461 s | 52.108–58.338 s | 5,049 | 92.68 |
+| B: report only | 53.848 s | 52.728–64.296 s | 6,719 | 122.93 |
+| C: report + timing | 53.470 s | 52.912–56.735 s | 6,703 | 125.63 |
+| D: timing only | 53.105 s | 52.099–59.489 s | 4,893 | 92.22 |
+
+The comparisons relevant to condition-timing overhead were:
+
+- B → C, with the Debug Report already enabled: median elapsed time changed by -0.378 seconds, median raw CPU ticks
+  changed by -16, and median duration-normalized CPU ticks changed by approximately +2.2%.
+- A → D, with the existing report disabled: median elapsed time changed by -1.356 seconds, median raw CPU ticks
+  changed by -156, and median duration-normalized CPU ticks changed by approximately -0.5%.
+
+Negative changes are not interpreted as performance improvements. The mixed directions and their size relative to
+run-to-run variance mean that the prototype's incremental cost did not stand out in this experiment. By contrast, the
+existing Debug Report path produced a clearly visible increase in process CPU ticks, which indicates that the method
+was capable of exposing an effect larger than the surrounding noise.
+
+All 20 runs completed successfully. Battery temperature rose from 41 °C to 45 °C during the early rotation and then
+remained at 45 °C. Android reported thermal status 0 throughout, so no run was marked as thermally throttled. Battery
+level fell from 67% to 52% across the complete experiment.
+
+## Data-integrity observations
+
+The ten timing-enabled runs produced:
+
+- 604,013 recorded condition checks;
+- 348.080 seconds of accumulated condition-processing time;
+- 29 configured conditions, of which 21 were reached;
+- the expected six successful completions for each scenario milestone condition; and
+- no missing or malformed profile output.
+
+The data also demonstrated the feature's intended value. Four conditions belonging to the same event accounted for
+229.524 seconds, or 65.94% of all measured condition-processing time. Two inexpensive conditions from another event
+were checked more than 80,000 times each and together accounted for another 10.82%. This shows why both cumulative
+time and check count are needed: an individually slow condition can be insignificant when rarely reached, while a
+cheap condition can become important through repetition.
+
+## Interpretation and limits
+
+The supported conclusion is that the approved aggregate design introduced no **detectable** overhead under this
+real-world workload. It is not a claim of mathematically zero cost, nor a general battery benchmark across devices.
+
+The permanent implementation preserves the properties exercised by the prototype:
+
+- no timing clock read when Debug Report generation is disabled;
+- no per-check allocation, coroutine, lock, or file operation;
+- primitive, fixed-size per-condition aggregates; and
+- one protobuf snapshot written through the existing serialized report writer when detection ends.
+
+Raw artifacts were retained locally during development, including per-run metadata, logs, profile CSV files, and the
+scenario database used to resolve condition names. They are not committed because they include a debug APK, device
+logs, and scenario-specific data; this document records the reproducible test design and aggregate results relevant to
+the architecture decision.

--- a/docs/debug-report-performance-timing.md
+++ b/docs/debug-report-performance-timing.md
@@ -1,0 +1,75 @@
+# Debug Report performance timing
+
+## Purpose
+
+Performance timing is part of the Debug Report. Its purpose is to help a scenario author find conditions that consume
+the most detection time and to show how much time the Execution Limiter deliberately kept detection idle.
+
+This data is diagnostic. It does not directly measure battery consumption and it does not attempt to explain time
+spent inside Android, other applications, or device hardware.
+
+## Enablement and ownership
+
+All performance timing is enabled and disabled with Debug Report generation. There is no separate condition profiler
+setting or output file. The Debug Report protobuf files are the only stored source of truth.
+
+The recorder, report models, protobuf schema, and mappings belong to the existing `core:smart:debugging` module. The
+processing module contains only the timing boundary and a small synchronous listener because condition evaluation and
+the Execution Limiter run there.
+
+When Debug Report generation is disabled:
+
+- no condition clock is read;
+- no performance aggregate is updated; and
+- the processing loop does not measure Execution Limiter suspension time.
+
+## Condition measurements
+
+A condition check starts immediately before `verifyCondition` and ends immediately after it returns. The duration
+therefore covers all work performed for that condition, including bitmap retrieval and the applicable detector call.
+
+- A check is counted only when a condition is actually reached and evaluated.
+- Conditions skipped by AND/OR short-circuiting are not counted.
+- Fulfilled means that the configured condition expression evaluated to true. For a negative screen condition, this
+  can mean that the image, color, text, or number was not detected.
+- Configured but unreached conditions remain in the report with zero checks and zero durations.
+
+For every configured condition, the report stores its database ID, check count, fulfilled count, total duration, and
+minimum and maximum duration. Durations are stored as integer nanoseconds. Nanoseconds are the storage unit and do not
+claim nanosecond measurement accuracy. A report reader chooses an appropriate display unit and derives averages and
+percentages from the raw values.
+
+A condition's time share uses the sum of all condition durations as its denominator. It must be described as a share
+of condition-processing time, not as a share of CPU, battery, or the whole detection session.
+
+## Session and Execution Limiter measurements
+
+The existing Debug Report overview stores whole-session elapsed time.
+
+Active detection-loop time is the accumulated duration of calls to `ScenarioProcessor.process`. The processing engine
+already measures each call to enforce the configured rate, so reporting the total requires only an aggregate update.
+It excludes the delay inserted after a loop by the Execution Limiter.
+
+Execution Limiter wait time measures elapsed suspension at the limiter's delay site. It is recorded only when the
+user-configured limiter is enabled. Safety delays used in unlimited mode and delays caused by unavailable screen
+frames or scenario actions are not limiter time. A partial limiter suspension interrupted by cancellation is retained.
+
+Session duration minus active detection-loop time is not treated as Execution Limiter time because that difference
+also contains actions and other waits.
+
+## Lifecycle and compatibility
+
+Aggregates are allocated and reset when a report session starts, updated synchronously from the single processing
+path, snapshotted once when the session ends, and written by the existing serialized Debug Report writer.
+
+Each session owns a fresh aggregate. Stopping, cancellation, orientation changes, or starting a later session must not
+mix values between reports. Timing must never change condition results or prevent detection from stopping normally.
+
+The condition profile is an optional protobuf message and new overview fields use new field numbers. Readers must
+continue to accept older reports, for which performance fields are absent and therefore decode to zero.
+
+## Deferred work
+
+This foundation does not include UI, optimization recommendations, fulfilled/unfulfilled timing splits, percentiles,
+histograms, CPU attribution, battery estimates, or system-process analysis. Those can be designed later without
+changing the meaning of the raw measurements above.

--- a/feature/smart-debugging/build.gradle.kts
+++ b/feature/smart-debugging/build.gradle.kts
@@ -17,6 +17,7 @@
 
 plugins {
     alias(libs.plugins.buzbuz.androidLibrary)
+    alias(libs.plugins.buzbuz.androidUnitTest)
     alias(libs.plugins.buzbuz.flavour)
     alias(libs.plugins.buzbuz.hilt)
 }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/di/Hilt.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/di/Hilt.kt
@@ -20,6 +20,7 @@ import com.buzbuz.smartautoclicker.core.common.overlays.di.OverlayComponent
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.live.conditiontry.TryImageConditionViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.live.eventtry.TryElementViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.DebugReportViewModel
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.EventActivityViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.overview.DebugReportOverviewViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.timeline.DebugReportTimelineViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.details.DebugReportEventOccurrenceDetailsViewModel
@@ -35,6 +36,7 @@ import dagger.hilt.InstallIn
 @EntryPoint
 @InstallIn(OverlayComponent::class)
 interface DebuggingViewModelsEntryPoint {
+    fun eventActivityViewModel(): EventActivityViewModel
     fun debugConditionContentViewModel(): DebugConditionContentViewModel
     fun debugCounterStateContentViewModel(): DebugCounterStateContentViewModel
     fun debugEventStateContentViewModel(): DebugEventsStateContentViewModel

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/di/Hilt.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/di/Hilt.kt
@@ -21,6 +21,7 @@ import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.live.condit
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.live.eventtry.TryElementViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.DebugReportViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.EventActivityViewModel
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.ConditionPerformanceViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.overview.DebugReportOverviewViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.timeline.DebugReportTimelineViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.details.DebugReportEventOccurrenceDetailsViewModel
@@ -37,6 +38,7 @@ import dagger.hilt.InstallIn
 @InstallIn(OverlayComponent::class)
 interface DebuggingViewModelsEntryPoint {
     fun eventActivityViewModel(): EventActivityViewModel
+    fun conditionPerformanceViewModel(): ConditionPerformanceViewModel
     fun debugConditionContentViewModel(): DebugConditionContentViewModel
     fun debugCounterStateContentViewModel(): DebugCounterStateContentViewModel
     fun debugEventStateContentViewModel(): DebugEventsStateContentViewModel

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/DebugReportDialog.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/DebugReportDialog.kt
@@ -30,6 +30,7 @@ import com.buzbuz.smartautoclicker.core.ui.bindings.dialogs.setButtonVisibility
 import com.buzbuz.smartautoclicker.feature.smart.debugging.R
 import com.buzbuz.smartautoclicker.feature.smart.debugging.di.DebuggingViewModelsEntryPoint
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.overview.DebugReportOverviewContent
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.ConditionPerformanceContent
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.timeline.DebugReportTimelineContent
 
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -62,6 +63,7 @@ class DebugReportDialog : NavBarDialog(R.style.AppTheme) {
 
     override fun onCreateContent(navItemId: Int): NavBarDialogContent = when (navItemId) {
         R.id.page_overview -> DebugReportOverviewContent(context.applicationContext)
+        R.id.page_conditions -> ConditionPerformanceContent(context.applicationContext)
         R.id.page_timeline -> DebugReportTimelineContent(context.applicationContext)
         else -> throw IllegalArgumentException("Unknown menu id $navItemId")
     }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityDialog.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityDialog.kt
@@ -1,0 +1,107 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+
+import com.buzbuz.smartautoclicker.core.common.overlays.base.viewModels
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.OverlayDialog
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.DialogEventActivityBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.di.DebuggingViewModelsEntryPoint
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.adapter.EventActivityAdapter
+
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import kotlinx.coroutines.launch
+
+
+class EventActivityDialog : OverlayDialog(R.style.AppTheme) {
+
+    private val viewModel: EventActivityViewModel by viewModels(
+        entryPoint = DebuggingViewModelsEntryPoint::class.java,
+        creator = { eventActivityViewModel() },
+    )
+
+    private lateinit var binding: DialogEventActivityBinding
+    private val adapter = EventActivityAdapter()
+
+    override fun onCreateView(): ViewGroup {
+        binding = DialogEventActivityBinding.inflate(LayoutInflater.from(context)).apply {
+            layoutTopBar.apply {
+                dialogTitle.setText(R.string.dialog_overlay_title_event_activity)
+                buttonDelete.visibility = View.GONE
+                buttonSave.visibility = View.GONE
+                buttonDismiss.setDebouncedOnClickListener { back() }
+            }
+
+            list.adapter = adapter
+            fastScroller.attachToRecyclerView(list)
+
+            floatingActionButtons.apply {
+                secondary.visibility = View.GONE
+                primaryBadge.visibility = View.GONE
+                primary.setImageResource(R.drawable.ic_sort)
+                primary.contentDescription = context.getString(R.string.content_desc_event_activity_sort)
+                primary.setOnClickListener { openSortDialog() }
+            }
+        }
+        return binding.root
+    }
+
+    override fun onDialogCreated(dialog: BottomSheetDialog) {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect(::updateUiState)
+            }
+        }
+    }
+
+    private fun updateUiState(uiState: EventActivityUiState) {
+        when (uiState) {
+            EventActivityUiState.Loading -> showLoading()
+            EventActivityUiState.NotAvailable -> back()
+            EventActivityUiState.Empty -> showEmpty()
+            is EventActivityUiState.Available -> showActivity(uiState)
+        }
+    }
+
+    private fun showLoading() = binding.apply {
+        loading.visibility = View.VISIBLE
+        empty.visibility = View.GONE
+        list.visibility = View.GONE
+        fastScroller.visibility = View.GONE
+        floatingActionButtons.root.visibility = View.GONE
+    }
+
+    private fun showEmpty() = binding.apply {
+        loading.visibility = View.GONE
+        empty.visibility = View.VISIBLE
+        list.visibility = View.GONE
+        fastScroller.visibility = View.GONE
+        floatingActionButtons.root.visibility = View.GONE
+    }
+
+    private fun showActivity(uiState: EventActivityUiState.Available) = binding.apply {
+        loading.visibility = View.GONE
+        empty.visibility = View.GONE
+        list.visibility = View.VISIBLE
+        fastScroller.visibility = View.VISIBLE
+        floatingActionButtons.root.visibility = View.VISIBLE
+        adapter.submitList(uiState.items) { fastScroller.refresh() }
+    }
+
+    private fun openSortDialog() {
+        overlayManager.navigateTo(
+            context = context,
+            newOverlay = EventActivitySortDialog(
+                selectedSort = viewModel.getSort(),
+                onSortSelected = viewModel::setSort,
+            ),
+            hideCurrent = false,
+        )
+    }
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityReport.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityReport.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 Kevin Buzeau
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity
+
+import com.buzbuz.smartautoclicker.core.domain.model.event.ScreenEvent
+import com.buzbuz.smartautoclicker.core.domain.model.event.TriggerEvent
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportEventOccurrence
+
+
+enum class EventActivityType {
+    SCREEN,
+    TRIGGER,
+}
+
+enum class EventActivitySort {
+    SCENARIO_ORDER,
+    MOST_FREQUENT,
+    FIRST_EXECUTION,
+}
+
+data class EventActivityKey(
+    val type: EventActivityType,
+    val eventId: Long,
+)
+
+data class EventActivitySource(
+    val key: EventActivityKey,
+    val name: String,
+    val scenarioOrder: Int,
+)
+
+data class EventActivityEntry(
+    val key: EventActivityKey,
+    val name: String,
+    val scenarioOrder: Int,
+    val occurrenceCount: Int,
+    val firstOccurrenceIndex: Int?,
+)
+
+data class EventActivityReport(
+    val reachedEventCount: Int,
+    val totalOccurrenceCount: Int,
+    val mostFrequentEvent: EventActivityEntry?,
+    val screenEvents: List<EventActivityEntry>,
+    val triggerEvents: List<EventActivityEntry>,
+)
+
+internal fun buildEventActivityReport(
+    screenEvents: List<EventActivitySource>,
+    triggerEvents: List<EventActivitySource>,
+    occurrences: List<DebugReportEventOccurrence>,
+    sort: EventActivitySort = EventActivitySort.SCENARIO_ORDER,
+): EventActivityReport {
+    val sourcesByKey = (screenEvents + triggerEvents).associateBy(EventActivitySource::key)
+    val occurrenceCounts = mutableMapOf<EventActivityKey, Int>()
+    val firstOccurrenceIndexes = mutableMapOf<EventActivityKey, Int>()
+
+    occurrences.forEachIndexed { index, occurrence ->
+        val key = occurrence.toEventActivityKey()
+        if (key !in sourcesByKey) return@forEachIndexed
+
+        occurrenceCounts[key] = occurrenceCounts.getOrDefault(key, 0) + 1
+        firstOccurrenceIndexes.putIfAbsent(key, index)
+    }
+
+    val allEntries = sourcesByKey.values.map { source ->
+        EventActivityEntry(
+            key = source.key,
+            name = source.name,
+            scenarioOrder = source.scenarioOrder,
+            occurrenceCount = occurrenceCounts.getOrDefault(source.key, 0),
+            firstOccurrenceIndex = firstOccurrenceIndexes[source.key],
+        )
+    }
+    val reachedEntries = allEntries.filter { entry -> entry.occurrenceCount > 0 }
+
+    return EventActivityReport(
+        reachedEventCount = reachedEntries.size,
+        totalOccurrenceCount = reachedEntries.sumOf(EventActivityEntry::occurrenceCount),
+        mostFrequentEvent = reachedEntries.sortedWith(mostFrequentComparator).firstOrNull(),
+        screenEvents = allEntries
+            .filter { entry -> entry.key.type == EventActivityType.SCREEN }
+            .sortedWith(sort.comparator()),
+        triggerEvents = allEntries
+            .filter { entry -> entry.key.type == EventActivityType.TRIGGER }
+            .sortedWith(sort.comparator()),
+    )
+}
+
+internal fun List<ScreenEvent>.toScreenEventActivitySources(): List<EventActivitySource> =
+    mapIndexed { index, event ->
+        EventActivitySource(
+            key = EventActivityKey(EventActivityType.SCREEN, event.id.databaseId),
+            name = event.name,
+            scenarioOrder = index,
+        )
+    }
+
+internal fun List<TriggerEvent>.toTriggerEventActivitySources(): List<EventActivitySource> =
+    mapIndexed { index, event ->
+        EventActivitySource(
+            key = EventActivityKey(EventActivityType.TRIGGER, event.id.databaseId),
+            name = event.name,
+            scenarioOrder = index,
+        )
+    }
+
+private fun DebugReportEventOccurrence.toEventActivityKey(): EventActivityKey =
+    when (this) {
+        is DebugReportEventOccurrence.ScreenEvent -> EventActivityKey(EventActivityType.SCREEN, eventId)
+        is DebugReportEventOccurrence.TriggerEvent -> EventActivityKey(EventActivityType.TRIGGER, eventId)
+    }
+
+private val scenarioOrderComparator: Comparator<EventActivityEntry> =
+    compareBy<EventActivityEntry> { entry -> entry.scenarioOrder }
+        .thenBy { entry -> entry.key.eventId }
+
+private val mostFrequentComparator: Comparator<EventActivityEntry> =
+    compareByDescending<EventActivityEntry> { entry -> entry.occurrenceCount }
+        .thenBy { entry -> entry.key.type.ordinal }
+        .then(scenarioOrderComparator)
+
+private val firstExecutionComparator: Comparator<EventActivityEntry> =
+    compareBy<EventActivityEntry> { entry -> entry.firstOccurrenceIndex ?: Int.MAX_VALUE }
+        .then(scenarioOrderComparator)
+
+private fun EventActivitySort.comparator(): Comparator<EventActivityEntry> =
+    when (this) {
+        EventActivitySort.SCENARIO_ORDER -> scenarioOrderComparator
+        EventActivitySort.MOST_FREQUENT -> mostFrequentComparator
+        EventActivitySort.FIRST_EXECUTION -> firstExecutionComparator
+    }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivitySortDialog.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivitySortDialog.kt
@@ -1,0 +1,34 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity
+
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.DialogChoice
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.MultiChoiceDialog
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+
+
+class EventActivitySortDialog(
+    selectedSort: EventActivitySort,
+    onSortSelected: (EventActivitySort) -> Unit,
+) : MultiChoiceDialog<EventActivitySortChoice>(
+    theme = R.style.AppTheme,
+    dialogTitleText = R.string.dialog_overlay_title_event_activity_sort,
+    choices = EventActivitySort.entries.map { sort -> EventActivitySortChoice(sort, sort == selectedSort) },
+    onChoiceSelected = { choice -> onSortSelected(choice.sort) },
+)
+
+class EventActivitySortChoice(
+    val sort: EventActivitySort,
+    selected: Boolean,
+) : DialogChoice(
+    title = when (sort) {
+        EventActivitySort.SCENARIO_ORDER -> R.string.event_activity_sort_scenario_order
+        EventActivitySort.MOST_FREQUENT -> R.string.event_activity_sort_most_frequent
+        EventActivitySort.FIRST_EXECUTION -> R.string.event_activity_sort_first_execution
+    },
+    description = when (sort) {
+        EventActivitySort.SCENARIO_ORDER -> R.string.event_activity_sort_scenario_order_desc
+        EventActivitySort.MOST_FREQUENT -> R.string.event_activity_sort_most_frequent_desc
+        EventActivitySort.FIRST_EXECUTION -> R.string.event_activity_sort_first_execution_desc
+    },
+    iconId = if (selected) R.drawable.ic_debug_confirm else null,
+)

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityUiState.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityUiState.kt
@@ -1,0 +1,17 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity
+
+sealed interface EventActivityUiState {
+    data object Loading : EventActivityUiState
+    data object NotAvailable : EventActivityUiState
+    data object Empty : EventActivityUiState
+    data class Available(
+        val items: List<EventActivityListItem>,
+        val sort: EventActivitySort,
+    ) : EventActivityUiState
+}
+
+sealed interface EventActivityListItem {
+    data class Header(val type: EventActivityType) : EventActivityListItem
+    data class Event(val activity: EventActivityEntry) : EventActivityListItem
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityViewModel.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityViewModel.kt
@@ -1,0 +1,80 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+
+import com.buzbuz.smartautoclicker.core.domain.IRepository
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.DebuggingRepository
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventActivityViewModel @Inject constructor(
+    debuggingRepository: DebuggingRepository,
+    smartRepository: IRepository,
+) : ViewModel() {
+
+    private val sort = MutableStateFlow(EventActivitySort.SCENARIO_ORDER)
+
+    val uiState: StateFlow<EventActivityUiState> = debuggingRepository.getLastReportOverview()
+        .flatMapLatest { overview ->
+            if (overview == null) return@flatMapLatest flowOf(EventActivityUiState.NotAvailable)
+
+            combine(
+                smartRepository.getScreenEventsFlow(overview.scenarioId),
+                smartRepository.getTriggerEventsFlow(overview.scenarioId),
+                debuggingRepository.getLastReportEventsOccurrences(),
+                sort,
+            ) { screenEvents, triggerEvents, occurrences, selectedSort ->
+                if (occurrences == null) return@combine EventActivityUiState.NotAvailable
+
+                val report = buildEventActivityReport(
+                    screenEvents = screenEvents.toScreenEventActivitySources(),
+                    triggerEvents = triggerEvents.toTriggerEventActivitySources(),
+                    occurrences = occurrences,
+                    sort = selectedSort,
+                )
+                report.toUiState(selectedSort)
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = EventActivityUiState.Loading,
+        )
+
+    fun setSort(selectedSort: EventActivitySort) {
+        sort.update { selectedSort }
+    }
+
+    fun getSort(): EventActivitySort = sort.value
+
+    private fun EventActivityReport.toUiState(sort: EventActivitySort): EventActivityUiState {
+        if (screenEvents.isEmpty() && triggerEvents.isEmpty()) return EventActivityUiState.Empty
+
+        return EventActivityUiState.Available(
+            items = buildList {
+                if (screenEvents.isNotEmpty()) {
+                    add(EventActivityListItem.Header(EventActivityType.SCREEN))
+                    addAll(screenEvents.map(EventActivityListItem::Event))
+                }
+                if (triggerEvents.isNotEmpty()) {
+                    add(EventActivityListItem.Header(EventActivityType.TRIGGER))
+                    addAll(triggerEvents.map(EventActivityListItem::Event))
+                }
+            },
+            sort = sort,
+        )
+    }
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/adapter/EventActivityAdapter.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/adapter/EventActivityAdapter.kt
@@ -1,0 +1,97 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ItemEventActivityBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ItemEventStateHeaderBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.EventActivityListItem
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.EventActivityType
+
+
+class EventActivityAdapter : ListAdapter<EventActivityListItem, RecyclerView.ViewHolder>(DiffCallback) {
+
+    override fun getItemViewType(position: Int): Int = when (getItem(position)) {
+        is EventActivityListItem.Header -> R.layout.item_event_state_header
+        is EventActivityListItem.Event -> R.layout.item_event_activity
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
+        when (viewType) {
+            R.layout.item_event_state_header -> HeaderViewHolder(parent)
+            R.layout.item_event_activity -> EventViewHolder(parent)
+            else -> error("Unknown Event Activity view type $viewType")
+        }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is HeaderViewHolder -> holder.bind(getItem(position) as EventActivityListItem.Header)
+            is EventViewHolder -> holder.bind(getItem(position) as EventActivityListItem.Event)
+        }
+    }
+}
+
+private class HeaderViewHolder private constructor(
+    private val binding: ItemEventStateHeaderBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    constructor(parent: ViewGroup) : this(
+        ItemEventStateHeaderBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+    )
+
+    fun bind(item: EventActivityListItem.Header) {
+        when (item.type) {
+            EventActivityType.SCREEN -> {
+                binding.sectionText.setText(R.string.item_event_activity_screen_events)
+                binding.sectionIcon.setImageResource(R.drawable.ic_screen_event)
+            }
+            EventActivityType.TRIGGER -> {
+                binding.sectionText.setText(R.string.item_event_activity_trigger_events)
+                binding.sectionIcon.setImageResource(R.drawable.ic_trigger_event)
+            }
+        }
+    }
+}
+
+private class EventViewHolder private constructor(
+    private val binding: ItemEventActivityBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    constructor(parent: ViewGroup) : this(
+        ItemEventActivityBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+    )
+
+    fun bind(item: EventActivityListItem.Event) {
+        val activity = item.activity
+        binding.eventNameText.text = activity.name
+        binding.occurrenceCountText.text = binding.root.context.getString(
+            R.string.item_event_activity_occurrence_count,
+            activity.occurrenceCount,
+        )
+
+        val alpha = if (activity.occurrenceCount == 0) UNREACHED_ALPHA else 1f
+        binding.eventNameText.alpha = alpha
+        binding.occurrenceCountText.alpha = alpha
+    }
+}
+
+private object DiffCallback : DiffUtil.ItemCallback<EventActivityListItem>() {
+    override fun areItemsTheSame(oldItem: EventActivityListItem, newItem: EventActivityListItem): Boolean =
+        when {
+            oldItem is EventActivityListItem.Header && newItem is EventActivityListItem.Header ->
+                oldItem.type == newItem.type
+            oldItem is EventActivityListItem.Event && newItem is EventActivityListItem.Event ->
+                oldItem.activity.key == newItem.activity.key
+            else -> false
+        }
+
+    override fun areContentsTheSame(oldItem: EventActivityListItem, newItem: EventActivityListItem): Boolean =
+        oldItem == newItem
+}
+
+private const val UNREACHED_ALPHA = 0.6f

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceContent.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceContent.kt
@@ -1,0 +1,93 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.navbar.NavBarDialogContent
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.navbar.viewModels
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ContentConditionPerformanceBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.di.DebuggingViewModelsEntryPoint
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.adapter.ConditionPerformanceAdapter
+import kotlinx.coroutines.launch
+
+class ConditionPerformanceContent(appContext: Context) : NavBarDialogContent(appContext) {
+
+    private val viewModel: ConditionPerformanceViewModel by viewModels(
+        entryPoint = DebuggingViewModelsEntryPoint::class.java,
+        creator = { conditionPerformanceViewModel() },
+    )
+    private val adapter = ConditionPerformanceAdapter(bitmapProvider = { condition, callback ->
+        viewModel.getConditionBitmap(condition, callback)
+    })
+    private lateinit var binding: ContentConditionPerformanceBinding
+
+    override fun floatingActionButtonsAreAvailable(): Boolean = true
+    override fun primaryFloatingActionButtonIcon(): Int = R.drawable.ic_sort
+
+    override fun onCreateView(container: ViewGroup): ViewGroup {
+        binding = ContentConditionPerformanceBinding.inflate(LayoutInflater.from(context), container, false).apply {
+            list.adapter = adapter
+            fastScroller.attachToRecyclerView(list)
+        }
+        return binding.root
+    }
+
+    override fun onViewCreated() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect(::updateUiState)
+            }
+        }
+    }
+
+    private fun updateUiState(uiState: ConditionPerformanceUiState) {
+        when (uiState) {
+            ConditionPerformanceUiState.Loading -> showLoading()
+            ConditionPerformanceUiState.NotAvailable -> showNotAvailable()
+            is ConditionPerformanceUiState.Available -> showAvailable(uiState)
+        }
+    }
+
+    private fun showLoading() = binding.apply {
+        loading.visibility = View.VISIBLE
+        unavailable.visibility = View.GONE
+        list.visibility = View.GONE
+        fastScroller.visibility = View.GONE
+        dialogController.floatingActionButtons.root.visibility = View.GONE
+    }
+
+    private fun showNotAvailable() = binding.apply {
+        loading.visibility = View.GONE
+        unavailable.visibility = View.VISIBLE
+        list.visibility = View.GONE
+        fastScroller.visibility = View.GONE
+        adapter.submitList(emptyList())
+        dialogController.floatingActionButtons.root.visibility = View.GONE
+    }
+
+    private fun showAvailable(uiState: ConditionPerformanceUiState.Available) = binding.apply {
+        loading.visibility = View.GONE
+        unavailable.visibility = View.GONE
+        list.visibility = View.VISIBLE
+        fastScroller.visibility = View.VISIBLE
+        dialogController.floatingActionButtons.root.visibility = View.VISIBLE
+        adapter.submitEntries(uiState.entries) { fastScroller.refresh() }
+    }
+
+    override fun onPrimaryFloatingActionButtonClicked() {
+        dialogController.overlayManager.navigateTo(
+            context = context,
+            newOverlay = ConditionPerformanceSortDialog(
+                selectedSort = viewModel.getSort(),
+                onSortSelected = viewModel::setSort,
+            ),
+            hideCurrent = false,
+        )
+    }
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceReport.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceReport.kt
@@ -1,0 +1,157 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions
+
+import com.buzbuz.smartautoclicker.core.domain.model.condition.Condition
+import com.buzbuz.smartautoclicker.core.domain.model.event.ScreenEvent
+import com.buzbuz.smartautoclicker.core.domain.model.event.TriggerEvent
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import java.text.NumberFormat
+import java.util.Locale
+
+enum class ConditionPerformanceSort {
+    TOTAL_TIME,
+    AVERAGE_PER_CHECK,
+    CHECKS,
+    SCENARIO_ORDER,
+}
+
+data class ConditionPerformanceSource(
+    val condition: Condition,
+    val eventName: String,
+    val scenarioOrder: Int,
+)
+
+data class ConditionPerformanceEntry(
+    val condition: Condition,
+    val eventName: String,
+    val checkCount: Long,
+    val fulfilledCount: Long,
+    val totalDurationNs: Long,
+    val minDurationNs: Long,
+    val maxDurationNs: Long,
+    val totalMeasuredDurationNs: Long,
+    val scenarioOrder: Int,
+) {
+    val averageDurationNs: BigDecimal?
+        get() = if (checkCount == 0L) null
+        else BigDecimal.valueOf(totalDurationNs).divide(BigDecimal.valueOf(checkCount), 12, RoundingMode.HALF_UP)
+}
+
+internal fun buildConditionPerformanceReport(
+    conditions: List<ConditionPerformanceSource>,
+    profiles: List<ConditionProfile>,
+    sort: ConditionPerformanceSort = ConditionPerformanceSort.TOTAL_TIME,
+): List<ConditionPerformanceEntry> {
+    val aggregatedProfiles = profiles
+        .groupBy(ConditionProfile::conditionId)
+        .mapValues { (_, entries) -> entries.aggregate() }
+    val totalMeasuredDurationNs = aggregatedProfiles.values.sumOf(ConditionProfile::totalDurationNs)
+
+    return conditions.map { source ->
+        val profile = aggregatedProfiles[source.condition.id.databaseId]
+        ConditionPerformanceEntry(
+            condition = source.condition,
+            eventName = source.eventName,
+            checkCount = profile?.checkCount ?: 0L,
+            fulfilledCount = profile?.fulfilledCount ?: 0L,
+            totalDurationNs = profile?.totalDurationNs ?: 0L,
+            minDurationNs = profile?.minDurationNs ?: 0L,
+            maxDurationNs = profile?.maxDurationNs ?: 0L,
+            totalMeasuredDurationNs = totalMeasuredDurationNs,
+            scenarioOrder = source.scenarioOrder,
+        )
+    }.sortedWith(sort.comparator())
+}
+
+internal fun buildConditionPerformanceReportOrNull(
+    conditions: List<ConditionPerformanceSource>,
+    profiles: List<ConditionProfile>?,
+    sort: ConditionPerformanceSort = ConditionPerformanceSort.TOTAL_TIME,
+): List<ConditionPerformanceEntry>? = profiles?.let { buildConditionPerformanceReport(conditions, it, sort) }
+
+internal fun List<ScreenEvent>.toScreenConditionPerformanceSources(): List<ConditionPerformanceSource> =
+    sortedBy(ScreenEvent::priority).flatMap { event ->
+        event.conditions.sortedBy { condition -> condition.priority }.map { condition ->
+            ConditionPerformanceSource(condition, event.name, scenarioOrder = 0)
+        }
+    }.mapIndexed { index, source -> source.copy(scenarioOrder = index) }
+
+internal fun List<TriggerEvent>.toTriggerConditionPerformanceSources(startingOrder: Int): List<ConditionPerformanceSource> =
+    flatMap { event ->
+        event.conditions.map { condition -> ConditionPerformanceSource(condition, event.name, scenarioOrder = 0) }
+    }.mapIndexed { index, source -> source.copy(scenarioOrder = startingOrder + index) }
+
+private fun List<ConditionProfile>.aggregate(): ConditionProfile =
+    ConditionProfile(
+        conditionId = first().conditionId,
+        checkCount = sumOf(ConditionProfile::checkCount),
+        fulfilledCount = sumOf(ConditionProfile::fulfilledCount),
+        totalDurationNs = sumOf(ConditionProfile::totalDurationNs),
+        minDurationNs = filter { it.checkCount > 0 }.minOfOrNull(ConditionProfile::minDurationNs) ?: 0L,
+        maxDurationNs = maxOfOrNull(ConditionProfile::maxDurationNs) ?: 0L,
+    )
+
+private fun ConditionPerformanceSort.comparator(): Comparator<ConditionPerformanceEntry> =
+    Comparator { left, right ->
+        val comparison = when (this) {
+            ConditionPerformanceSort.TOTAL_TIME -> right.totalDurationNs.compareTo(left.totalDurationNs)
+            ConditionPerformanceSort.CHECKS -> right.checkCount.compareTo(left.checkCount)
+            ConditionPerformanceSort.AVERAGE_PER_CHECK -> compareAverageDescending(left, right)
+            ConditionPerformanceSort.SCENARIO_ORDER -> left.scenarioOrder.compareTo(right.scenarioOrder)
+        }
+        if (comparison != 0) comparison else left.scenarioOrder.compareTo(right.scenarioOrder)
+    }
+
+private fun compareAverageDescending(
+    left: ConditionPerformanceEntry,
+    right: ConditionPerformanceEntry,
+): Int {
+    if (left.checkCount == 0L) return if (right.checkCount == 0L) 0 else 1
+    if (right.checkCount == 0L) return -1
+
+    val leftRatio = BigInteger.valueOf(left.totalDurationNs).multiply(BigInteger.valueOf(right.checkCount))
+    val rightRatio = BigInteger.valueOf(right.totalDurationNs).multiply(BigInteger.valueOf(left.checkCount))
+    return rightRatio.compareTo(leftRatio)
+}
+
+internal fun formatTotalDuration(totalDurationNs: Long): String =
+    formatWithFourSignificantDigits(BigDecimal.valueOf(totalDurationNs, 9))
+
+internal fun formatAverageDuration(totalDurationNs: Long, checkCount: Long): String? {
+    if (checkCount == 0L) return null
+    val averageMs = BigDecimal.valueOf(totalDurationNs)
+        .divide(BigDecimal.valueOf(checkCount), 6, RoundingMode.HALF_UP)
+        .movePointLeft(6)
+    return formatWithFourSignificantDigits(averageMs)
+}
+
+internal fun formatPercentage(totalDurationNs: Long, totalMeasuredDurationNs: Long): String {
+    if (totalDurationNs == 0L || totalMeasuredDurationNs == 0L) return "0%"
+    if (totalDurationNs == totalMeasuredDurationNs) return "100%"
+
+    val percentage = BigDecimal.valueOf(totalDurationNs)
+        .multiply(BigDecimal.valueOf(100))
+        .divide(BigDecimal.valueOf(totalMeasuredDurationNs), 8, RoundingMode.HALF_UP)
+    if (percentage < BigDecimal("0.01")) return "<0.01%"
+
+    val rounded = percentage.setScale(2, RoundingMode.HALF_UP).min(BigDecimal("99.99"))
+    return "${rounded.toPlainString()}%"
+}
+
+internal fun formatCount(value: Long, locale: Locale = Locale.getDefault()): String =
+    NumberFormat.getIntegerInstance(locale).format(value)
+
+private fun formatWithFourSignificantDigits(value: BigDecimal): String {
+    if (value.signum() == 0) return "0"
+
+    val normalized = value.abs().stripTrailingZeros()
+    val digitsBeforeDecimal = normalized.precision() - normalized.scale()
+    val decimalPlaces = (SIGNIFICANT_DIGITS - digitsBeforeDecimal).coerceAtLeast(0)
+    val rounded = value.setScale(decimalPlaces, RoundingMode.HALF_UP).stripTrailingZeros()
+    return rounded.toPlainString()
+}
+
+private const val SIGNIFICANT_DIGITS = 4

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceSortDialog.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceSortDialog.kt
@@ -1,0 +1,37 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions
+
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.DialogChoice
+import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.MultiChoiceDialog
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+
+class ConditionPerformanceSortDialog(
+    selectedSort: ConditionPerformanceSort,
+    onSortSelected: (ConditionPerformanceSort) -> Unit,
+) : MultiChoiceDialog<ConditionPerformanceSortChoice>(
+    theme = R.style.AppTheme,
+    dialogTitleText = R.string.dialog_overlay_title_condition_performance_sort,
+    choices = ConditionPerformanceSort.entries.map { sort ->
+        ConditionPerformanceSortChoice(sort, sort == selectedSort)
+    },
+    onChoiceSelected = { choice -> onSortSelected(choice.sort) },
+)
+
+class ConditionPerformanceSortChoice(
+    val sort: ConditionPerformanceSort,
+    selected: Boolean,
+) : DialogChoice(
+    title = when (sort) {
+        ConditionPerformanceSort.TOTAL_TIME -> R.string.condition_performance_sort_total_time
+        ConditionPerformanceSort.AVERAGE_PER_CHECK -> R.string.condition_performance_sort_average
+        ConditionPerformanceSort.CHECKS -> R.string.condition_performance_sort_checks
+        ConditionPerformanceSort.SCENARIO_ORDER -> R.string.condition_performance_sort_scenario_order
+    },
+    description = when (sort) {
+        ConditionPerformanceSort.TOTAL_TIME -> R.string.condition_performance_sort_total_time_desc
+        ConditionPerformanceSort.AVERAGE_PER_CHECK -> R.string.condition_performance_sort_average_desc
+        ConditionPerformanceSort.CHECKS -> R.string.condition_performance_sort_checks_desc
+        ConditionPerformanceSort.SCENARIO_ORDER -> R.string.condition_performance_sort_scenario_order_desc
+    },
+    iconId = if (selected) R.drawable.ic_debug_confirm else null,
+)

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceUiState.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceUiState.kt
@@ -1,0 +1,11 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions
+
+sealed interface ConditionPerformanceUiState {
+    data object Loading : ConditionPerformanceUiState
+    data object NotAvailable : ConditionPerformanceUiState
+    data class Available(
+        val entries: List<ConditionPerformanceEntry>,
+        val sort: ConditionPerformanceSort,
+    ) : ConditionPerformanceUiState
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceViewModel.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceViewModel.kt
@@ -1,0 +1,86 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions
+
+import android.graphics.Bitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.buzbuz.smartautoclicker.core.base.di.Dispatcher
+import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.IO
+import com.buzbuz.smartautoclicker.core.base.di.HiltCoroutineDispatchers.Main
+import com.buzbuz.smartautoclicker.core.bitmaps.BitmapRepository
+import com.buzbuz.smartautoclicker.core.domain.IRepository
+import com.buzbuz.smartautoclicker.core.domain.ext.getConditionBitmap
+import com.buzbuz.smartautoclicker.core.domain.model.condition.ScreenCondition
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.DebuggingRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConditionPerformanceViewModel @Inject constructor(
+    debuggingRepository: DebuggingRepository,
+    smartRepository: IRepository,
+    private val bitmapRepository: BitmapRepository,
+    @param:Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
+    @param:Dispatcher(Main) private val mainDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val sort = MutableStateFlow(ConditionPerformanceSort.TOTAL_TIME)
+
+    val uiState: StateFlow<ConditionPerformanceUiState> = debuggingRepository.getLastReportOverview()
+        .flatMapLatest { overview ->
+            if (overview == null) return@flatMapLatest flowOf(ConditionPerformanceUiState.NotAvailable)
+
+            combine(
+                smartRepository.getScreenEventsFlow(overview.scenarioId),
+                smartRepository.getTriggerEventsFlow(overview.scenarioId),
+                debuggingRepository.getLastReportConditionProfiles(),
+                sort,
+            ) { screenEvents, triggerEvents, profiles, selectedSort ->
+                val screenConditions = screenEvents.toScreenConditionPerformanceSources()
+                val triggerConditions = triggerEvents.toTriggerConditionPerformanceSources(screenConditions.size)
+                val entries = buildConditionPerformanceReportOrNull(
+                    conditions = screenConditions + triggerConditions,
+                    profiles = profiles,
+                    sort = selectedSort,
+                ) ?: return@combine ConditionPerformanceUiState.NotAvailable
+                ConditionPerformanceUiState.Available(
+                    entries = entries,
+                    sort = selectedSort,
+                )
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = ConditionPerformanceUiState.Loading,
+        )
+
+    fun setSort(selectedSort: ConditionPerformanceSort) {
+        sort.update { selectedSort }
+    }
+
+    fun getSort(): ConditionPerformanceSort = sort.value
+
+    fun getConditionBitmap(condition: ScreenCondition.Image, onBitmapLoaded: (Bitmap?) -> Unit): Job =
+        viewModelScope.launch(ioDispatcher) {
+            try {
+                val bitmap = bitmapRepository.getConditionBitmap(condition)
+                withContext(mainDispatcher) { onBitmapLoaded(bitmap) }
+            } catch (_: CancellationException) {
+                withContext(mainDispatcher) { onBitmapLoaded(null) }
+            }
+        }
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/adapter/ConditionPerformanceAdapter.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/adapter/ConditionPerformanceAdapter.kt
@@ -1,0 +1,143 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.adapter
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.buzbuz.smartautoclicker.core.domain.model.condition.ScreenCondition
+import com.buzbuz.smartautoclicker.core.domain.model.condition.TriggerCondition
+import com.buzbuz.smartautoclicker.core.ui.utils.setColorIndicatorDrawable
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ItemConditionPerformanceBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ItemConditionPerformanceFooterBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.ConditionPerformanceEntry
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.formatAverageDuration
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.formatCount
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.formatPercentage
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions.formatTotalDuration
+import kotlinx.coroutines.Job
+
+internal sealed interface ConditionPerformanceListItem {
+    data class Condition(val entry: ConditionPerformanceEntry) : ConditionPerformanceListItem
+    data object Footer : ConditionPerformanceListItem
+}
+
+internal class ConditionPerformanceAdapter(
+    private val bitmapProvider: (ScreenCondition.Image, (Bitmap?) -> Unit) -> Job,
+) : ListAdapter<ConditionPerformanceListItem, RecyclerView.ViewHolder>(DiffCallback) {
+
+    fun submitEntries(entries: List<ConditionPerformanceEntry>, commitCallback: (() -> Unit)? = null) {
+        submitList(entries.map(ConditionPerformanceListItem::Condition) + ConditionPerformanceListItem.Footer, commitCallback)
+    }
+
+    override fun getItemViewType(position: Int): Int = when (getItem(position)) {
+        is ConditionPerformanceListItem.Condition -> R.layout.item_condition_performance
+        ConditionPerformanceListItem.Footer -> R.layout.item_condition_performance_footer
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
+        when (viewType) {
+            R.layout.item_condition_performance -> ConditionViewHolder(parent, bitmapProvider)
+            R.layout.item_condition_performance_footer -> FooterViewHolder(parent)
+            else -> error("Unknown condition performance view type $viewType")
+        }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is ConditionViewHolder) {
+            holder.bind((getItem(position) as ConditionPerformanceListItem.Condition).entry)
+        }
+    }
+
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        if (holder is ConditionViewHolder) holder.unbind()
+        super.onViewRecycled(holder)
+    }
+}
+
+private class ConditionViewHolder private constructor(
+    private val binding: ItemConditionPerformanceBinding,
+    private val bitmapProvider: (ScreenCondition.Image, (Bitmap?) -> Unit) -> Job,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    constructor(
+        parent: ViewGroup,
+        bitmapProvider: (ScreenCondition.Image, (Bitmap?) -> Unit) -> Job,
+    ) : this(
+        ItemConditionPerformanceBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        bitmapProvider,
+    )
+
+    private var bitmapLoadingJob: Job? = null
+
+    fun bind(entry: ConditionPerformanceEntry) = binding.apply {
+        bitmapLoadingJob?.cancel()
+        bitmapLoadingJob = null
+        conditionImage.setImageDrawable(null)
+        conditionNameText.text = entry.condition.name
+        eventNameText.text = entry.eventName
+        totalTimeText.text = root.context.getString(
+            R.string.item_condition_performance_total_time,
+            formatTotalDuration(entry.totalDurationNs),
+        )
+
+        val fulfilledCount = formatCount(entry.fulfilledCount)
+        val checkCount = formatCount(entry.checkCount)
+        fulfilledText.text = root.context.getString(
+            R.string.item_condition_performance_fulfilled,
+            fulfilledCount,
+            root.resources.getQuantityString(R.plurals.item_condition_performance_time, entry.fulfilledCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()),
+            checkCount,
+            root.resources.getQuantityString(R.plurals.item_condition_performance_check, entry.checkCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()),
+        )
+        averageText.text = formatAverageDuration(entry.totalDurationNs, entry.checkCount)?.let { average ->
+            root.context.getString(R.string.item_condition_performance_average, average)
+        } ?: root.context.getString(R.string.item_condition_performance_average_unavailable)
+        percentageText.text = formatPercentage(entry.totalDurationNs, entry.totalMeasuredDurationNs)
+
+        when (val condition = entry.condition) {
+            is ScreenCondition.Color -> conditionImage.setColorIndicatorDrawable(condition.color)
+            is ScreenCondition.Image -> bitmapLoadingJob = bitmapProvider(condition) { bitmap ->
+                if (bitmap != null) conditionImage.setImageBitmap(bitmap)
+                else conditionImage.setImageDrawable(ContextCompat.getDrawable(root.context, R.drawable.ic_cancel)?.apply {
+                    setTint(Color.RED)
+                })
+            }
+            is ScreenCondition.Number -> conditionImage.setImageResource(R.drawable.ic_number_condition)
+            is ScreenCondition.Text -> conditionImage.setImageResource(R.drawable.ic_text_condition)
+            is TriggerCondition.OnBroadcastReceived -> conditionImage.setImageResource(R.drawable.ic_broadcast_received)
+            is TriggerCondition.OnCounterCountReached -> conditionImage.setImageResource(R.drawable.ic_counter_reached)
+            is TriggerCondition.OnTimerReached -> conditionImage.setImageResource(R.drawable.ic_timer_reached)
+        }
+    }
+
+    fun unbind() {
+        bitmapLoadingJob?.cancel()
+        bitmapLoadingJob = null
+    }
+}
+
+private class FooterViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
+    ItemConditionPerformanceFooterBinding.inflate(LayoutInflater.from(parent.context), parent, false).root,
+)
+
+private object DiffCallback : DiffUtil.ItemCallback<ConditionPerformanceListItem>() {
+    override fun areItemsTheSame(
+        oldItem: ConditionPerformanceListItem,
+        newItem: ConditionPerformanceListItem,
+    ): Boolean = when {
+        oldItem is ConditionPerformanceListItem.Condition && newItem is ConditionPerformanceListItem.Condition ->
+            oldItem.entry.condition.id == newItem.entry.condition.id
+        oldItem is ConditionPerformanceListItem.Footer && newItem is ConditionPerformanceListItem.Footer -> true
+        else -> false
+    }
+
+    override fun areContentsTheSame(
+        oldItem: ConditionPerformanceListItem,
+        newItem: ConditionPerformanceListItem,
+    ): Boolean = oldItem == newItem
+}

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/overview/DebugReportOverviewContent.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/overview/DebugReportOverviewContent.kt
@@ -29,8 +29,10 @@ import com.buzbuz.smartautoclicker.core.common.overlays.dialog.implementation.na
 import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setDescription
 import com.buzbuz.smartautoclicker.core.ui.bindings.fields.setTitle
 import com.buzbuz.smartautoclicker.core.ui.databinding.IncludeFieldDataDisplayBinding
+import com.buzbuz.smartautoclicker.feature.smart.debugging.R
 import com.buzbuz.smartautoclicker.feature.smart.debugging.databinding.ContentDebugReportOverviewBinding
 import com.buzbuz.smartautoclicker.feature.smart.debugging.di.DebuggingViewModelsEntryPoint
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.EventActivityDialog
 
 import kotlinx.coroutines.launch
 import kotlin.getValue
@@ -47,7 +49,9 @@ class DebugReportOverviewContent(appContext: Context) : NavBarDialogContent(appC
     private lateinit var viewBinding: ContentDebugReportOverviewBinding
 
     override fun onCreateView(container: ViewGroup): ViewGroup {
-        viewBinding = ContentDebugReportOverviewBinding.inflate(LayoutInflater.from(context), container, false)
+        viewBinding = ContentDebugReportOverviewBinding.inflate(LayoutInflater.from(context), container, false).apply {
+            eventActivity.root.setOnClickListener { openEventActivity() }
+        }
         return viewBinding.root
     }
 
@@ -89,7 +93,36 @@ class DebugReportOverviewContent(appContext: Context) : NavBarDialogContent(appC
             fieldAvgImgProcDur.bindEntry(state.averageFrameProcessingDuration)
             fieldImgEvtFulfilledCount.bindEntry(state.imageEventFulfilledCount)
             fieldTriggerEvtFulfilledCount.bindEntry(state.triggerEventFulfilledCount)
+            eventActivity.summaryData.apply {
+                setTitle(context.getString(R.string.item_title_report_event_activity))
+                setDescription(state.eventActivity.formatDescription())
+            }
         }
+    }
+
+    private fun EventActivitySummary.formatDescription(): String {
+        if (reachedEventCount == 0) return context.getString(R.string.item_desc_report_event_activity_empty)
+
+        val counts = context.resources.getQuantityString(
+            R.plurals.item_desc_report_event_activity_reached,
+            reachedEventCount,
+            reachedEventCount,
+            totalOccurrenceCount,
+        )
+        val mostFrequent = context.getString(
+            R.string.item_desc_report_event_activity_most_frequent,
+            mostFrequentEventName,
+            mostFrequentEventCount,
+        )
+        return "$counts\n$mostFrequent"
+    }
+
+    private fun openEventActivity() {
+        dialogController.overlayManager.navigateTo(
+            context = context,
+            newOverlay = EventActivityDialog(),
+            hideCurrent = false,
+        )
     }
 
     private fun IncludeFieldDataDisplayBinding.bindEntry(entry: OverviewEntry) {

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/overview/DebugReportOverviewUiState.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/overview/DebugReportOverviewUiState.kt
@@ -30,10 +30,18 @@ sealed interface DebugReportOverviewUiState {
         val averageFrameProcessingDuration: OverviewEntry,
         val imageEventFulfilledCount: OverviewEntry,
         val triggerEventFulfilledCount: OverviewEntry,
+        val eventActivity: EventActivitySummary,
     ) : DebugReportOverviewUiState
 }
 
 data class OverviewEntry(
     @field:StringRes val titleRes: Int,
     val value: String,
+)
+
+data class EventActivitySummary(
+    val reachedEventCount: Int,
+    val totalOccurrenceCount: Int,
+    val mostFrequentEventName: String?,
+    val mostFrequentEventCount: Int?,
 )

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/overview/DebugReportOverviewViewModel.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/overview/DebugReportOverviewViewModel.kt
@@ -20,36 +20,62 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 
 import com.buzbuz.smartautoclicker.core.domain.IRepository
+import com.buzbuz.smartautoclicker.core.domain.model.event.ScreenEvent
+import com.buzbuz.smartautoclicker.core.domain.model.event.TriggerEvent
+import com.buzbuz.smartautoclicker.core.domain.model.scenario.Scenario
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.DebuggingRepository
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportEventOccurrence
 import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportOverview
 import com.buzbuz.smartautoclicker.feature.smart.debugging.R
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.buildEventActivityReport
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.toScreenEventActivitySources
+import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity.toTriggerEventActivitySources
 
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DebugReportOverviewViewModel @Inject constructor(
     debuggingRepository: DebuggingRepository,
-    private val smartRepository: IRepository,
+    smartRepository: IRepository,
 ) : ViewModel() {
 
-    private val lastReportOverview: Flow<DebugReportOverview?> = debuggingRepository.getLastReportOverview()
+    private val reportData = debuggingRepository.getLastReportOverview().flatMapLatest { overview ->
+        if (overview == null) return@flatMapLatest flowOf(null)
 
-    val uiState: StateFlow<DebugReportOverviewUiState> = lastReportOverview
-        .map { overview -> overview.toUiState() }
+        combine(
+            smartRepository.getScenarioFlow(overview.scenarioId),
+            smartRepository.getScreenEventsFlow(overview.scenarioId),
+            smartRepository.getTriggerEventsFlow(overview.scenarioId),
+            debuggingRepository.getLastReportEventsOccurrences(),
+        ) { scenario, screenEvents, triggerEvents, occurrences ->
+            OverviewReportData(overview, scenario, screenEvents, triggerEvents, occurrences)
+        }
+    }
+
+    val uiState: StateFlow<DebugReportOverviewUiState> = reportData
+        .map { data -> data.toUiState() }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = DebugReportOverviewUiState.Loading,
         )
 
-    private suspend fun DebugReportOverview?.toUiState(): DebugReportOverviewUiState {
-        if (this == null) return DebugReportOverviewUiState.NotAvailable
-        val scenario = smartRepository.getScenario(scenarioId) ?: return DebugReportOverviewUiState.NotAvailable
+    private fun OverviewReportData?.toUiState(): DebugReportOverviewUiState {
+        if (this == null || scenario == null || occurrences == null) return DebugReportOverviewUiState.NotAvailable
+        val activity = buildEventActivityReport(
+            screenEvents = screenEvents.toScreenEventActivitySources(),
+            triggerEvents = triggerEvents.toTriggerEventActivitySources(),
+            occurrences = occurrences,
+        )
 
         return DebugReportOverviewUiState.Available(
             scenario = OverviewEntry(
@@ -58,25 +84,39 @@ class DebugReportOverviewViewModel @Inject constructor(
             ),
             totalDuration = OverviewEntry(
                 titleRes = R.string.item_title_report_total_duration,
-                value = duration.toString(),
+                value = overview.duration.toString(),
             ),
             frameCount = OverviewEntry(
                 titleRes = R.string.item_title_report_frame_processed,
-                value = frameCount.toString(),
+                value = overview.frameCount.toString(),
             ),
             averageFrameProcessingDuration = OverviewEntry(
                 titleRes = R.string.item_title_report_avg_image_processing_duration,
-                value = averageFrameProcessingDuration.toString(),
+                value = overview.averageFrameProcessingDuration.toString(),
             ),
             imageEventFulfilledCount = OverviewEntry(
                 titleRes = R.string.item_title_report_image_event_fulfilled,
-                value = imageEventFulfilledCount.toString(),
+                value = overview.imageEventFulfilledCount.toString(),
             ),
             triggerEventFulfilledCount = OverviewEntry(
                 titleRes = R.string.item_title_report_trigger_event_fulfilled,
-                value = triggerEventFulfilledCount.toString(),
+                value = overview.triggerEventFulfilledCount.toString(),
+            ),
+            eventActivity = EventActivitySummary(
+                reachedEventCount = activity.reachedEventCount,
+                totalOccurrenceCount = activity.totalOccurrenceCount,
+                mostFrequentEventName = activity.mostFrequentEvent?.name,
+                mostFrequentEventCount = activity.mostFrequentEvent?.occurrenceCount,
             ),
         )
     }
 
 }
+
+private data class OverviewReportData(
+    val overview: DebugReportOverview,
+    val scenario: Scenario?,
+    val screenEvents: List<ScreenEvent>,
+    val triggerEvents: List<TriggerEvent>,
+    val occurrences: List<DebugReportEventOccurrence>?,
+)

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/DebugReportTimelineContent.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/DebugReportTimelineContent.kt
@@ -58,6 +58,8 @@ class DebugReportTimelineContent(appContext: Context) : NavBarDialogContent(appC
     override fun onCreateView(container: ViewGroup): ViewGroup {
         viewBinding = ContentDebugReportTimelineBinding.inflate(LayoutInflater.from(context), container, false).apply {
             list.adapter = timelineAdapter
+            fastScroller.attachToRecyclerView(list)
+            buttonClearFilters.setOnClickListener { viewModel.clearFilters() }
         }
 
         return viewBinding.root
@@ -71,9 +73,18 @@ class DebugReportTimelineContent(appContext: Context) : NavBarDialogContent(appC
         }
     }
 
+    override fun onStart() {
+        updateFiltersBadge(viewModel.uiState.value.activeFilterCount())
+    }
+
+    override fun onStop() {
+        dialogController.floatingActionButtons.primaryBadge.visibility = View.GONE
+    }
+
     private fun updateUiState(uiState: DebugReportTimelineUiState) {
         when (uiState) {
             DebugReportTimelineUiState.Empty -> toEmptyState()
+            is DebugReportTimelineUiState.FilteredEmpty -> toFilteredEmptyState(uiState)
             DebugReportTimelineUiState.Loading -> toLoadingState()
             DebugReportTimelineUiState.NotAvailable -> toNotAvailableState()
             is DebugReportTimelineUiState.Available -> toAvailableState(uiState)
@@ -84,14 +95,35 @@ class DebugReportTimelineContent(appContext: Context) : NavBarDialogContent(appC
         viewBinding.apply {
             loading.visibility = View.GONE
             list.visibility = View.GONE
+            fastScroller.visibility = View.GONE
             empty.visibility = View.VISIBLE
+            emptyTitle.setText(R.string.title_event_occurrence_empty)
+            emptySecondary.visibility = View.GONE
+            buttonClearFilters.visibility = View.GONE
         }
+        updateFiltersBadge(0)
+    }
+
+    private fun toFilteredEmptyState(uiState: DebugReportTimelineUiState.FilteredEmpty) {
+        viewBinding.apply {
+            loading.visibility = View.GONE
+            list.visibility = View.GONE
+            fastScroller.visibility = View.GONE
+            empty.visibility = View.VISIBLE
+            emptyTitle.setText(R.string.title_event_occurrence_filtered_empty)
+            emptySecondary.visibility = View.VISIBLE
+            emptySecondaryText.setText(R.string.desc_event_occurrence_filtered_empty)
+            buttonClearFilters.visibility = View.VISIBLE
+        }
+        timelineAdapter.submitList(emptyList())
+        updateFiltersBadge(uiState.activeFilterCount)
     }
 
     private fun toLoadingState() {
         viewBinding.apply {
             loading.visibility = View.VISIBLE
             list.visibility = View.GONE
+            fastScroller.visibility = View.GONE
             empty.visibility = View.GONE
         }
     }
@@ -104,9 +136,30 @@ class DebugReportTimelineContent(appContext: Context) : NavBarDialogContent(appC
         viewBinding.apply {
             loading.visibility = View.GONE
             list.visibility = View.VISIBLE
+            fastScroller.visibility = View.VISIBLE
             empty.visibility = View.GONE
         }
-        timelineAdapter.submitList(uiState.eventsOccurrences)
+        timelineAdapter.submitList(uiState.eventsOccurrences) {
+            viewBinding.fastScroller.refresh()
+        }
+        updateFiltersBadge(uiState.activeFilterCount)
+    }
+
+    private fun updateFiltersBadge(activeFilterCount: Int) {
+        dialogController.floatingActionButtons.primaryBadge.apply {
+            visibility = if (activeFilterCount > 0) View.VISIBLE else View.GONE
+            text = activeFilterCount.toString()
+            contentDescription = context.getString(
+                R.string.content_desc_timeline_filters_active,
+                activeFilterCount,
+            )
+        }
+    }
+
+    private fun DebugReportTimelineUiState.activeFilterCount(): Int = when (this) {
+        is DebugReportTimelineUiState.Available -> activeFilterCount
+        is DebugReportTimelineUiState.FilteredEmpty -> activeFilterCount
+        else -> 0
     }
 
     private fun onEventOccurrenceClicked(occurrence: DebugReportTimelineEventOccurrenceItem) {
@@ -125,7 +178,11 @@ class DebugReportTimelineContent(appContext: Context) : NavBarDialogContent(appC
             context = context,
             newOverlay = DebugReportTimelineFiltersDialog(
                 reportDurationMs = viewModel.uiState.value.let { uiState ->
-                    if (uiState is DebugReportTimelineUiState.Available) uiState.durationMs else 0L
+                    when (uiState) {
+                        is DebugReportTimelineUiState.Available -> uiState.durationMs
+                        is DebugReportTimelineUiState.FilteredEmpty -> uiState.durationMs
+                        else -> 0L
+                    }
                 },
                 currentFilters = viewModel.getFilters(),
                 onFiltersApplied = viewModel::setFilters,

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/DebugReportTimelineUiState.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/DebugReportTimelineUiState.kt
@@ -25,9 +25,14 @@ sealed interface DebugReportTimelineUiState {
     data object Loading : DebugReportTimelineUiState
     data object NotAvailable : DebugReportTimelineUiState
     data object Empty: DebugReportTimelineUiState
+    data class FilteredEmpty(
+        val durationMs: Long,
+        val activeFilterCount: Int,
+    ) : DebugReportTimelineUiState
     data class Available(
         val eventsOccurrences: List<DebugReportTimelineEventOccurrenceItem>,
         val durationMs: Long,
+        val activeFilterCount: Int,
     ) : DebugReportTimelineUiState
 
 }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/DebugReportTimelineViewModel.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/DebugReportTimelineViewModel.kt
@@ -105,6 +105,10 @@ class DebugReportTimelineViewModel @Inject constructor(
 
     fun getFilters(): List<DebugReportTimelineFilter> = filters.value
 
+    fun clearFilters() {
+        filters.value = emptyList()
+    }
+
     private fun List<DebugReportEventOccurrence>?.toUiState(
         context: Context,
         screenEvents: List<ScreenEvent>?,
@@ -115,12 +119,31 @@ class DebugReportTimelineViewModel @Inject constructor(
 
         val items = toUiStateItems(context, screenEvents, trigEvents, filters)
 
-        return if (isEmpty()) DebugReportTimelineUiState.Empty
-        else DebugReportTimelineUiState.Available(
-            eventsOccurrences = items,
-            durationMs = last().relativeTimestampMs,
-        )
+        val activeFilterCount = filters.getActiveCategoryCount(durationMs = lastOrNull()?.relativeTimestampMs ?: 0L)
+
+        return when {
+            isEmpty() -> DebugReportTimelineUiState.Empty
+            items.isEmpty() -> DebugReportTimelineUiState.FilteredEmpty(
+                durationMs = last().relativeTimestampMs,
+                activeFilterCount = activeFilterCount,
+            )
+            else -> DebugReportTimelineUiState.Available(
+                eventsOccurrences = items,
+                durationMs = last().relativeTimestampMs,
+                activeFilterCount = activeFilterCount,
+            )
+        }
     }
+
+    private fun List<DebugReportTimelineFilter>.getActiveCategoryCount(durationMs: Long): Int =
+        count { filter ->
+            when (filter) {
+                is DebugReportTimelineFilter.Time ->
+                    filter.lowerBoundMs > 0L || filter.upperBoundMs < durationMs
+                is DebugReportTimelineFilter.Events ->
+                    filter.filterAll || filter.filteredIds.isNotEmpty()
+            }
+        }
 
     private fun List<DebugReportEventOccurrence>.toUiStateItems(
         context: Context,

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/adapter/DebugReportTimelineEventActionsAdapter.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/adapter/DebugReportTimelineEventActionsAdapter.kt
@@ -17,30 +17,26 @@
 package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.timeline.adapter
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.timeline.DebugReportTimelineEventActionItem
 
 
-class DebugReportTimelineEventActionsAdapter()
-    : ListAdapter<DebugReportTimelineEventActionItem, ItemTimelineEventActionsViewHolder>(EventActionsItemDiffUtilCallback) {
+class DebugReportTimelineEventActionsAdapter
+    : RecyclerView.Adapter<ItemTimelineEventActionsViewHolder>() {
+
+    private var items: List<DebugReportTimelineEventActionItem> = emptyList()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemTimelineEventActionsViewHolder =
         ItemTimelineEventActionsViewHolder(parent)
 
     override fun onBindViewHolder(holder: ItemTimelineEventActionsViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(items[position])
     }
-}
 
-private object EventActionsItemDiffUtilCallback: DiffUtil.ItemCallback<DebugReportTimelineEventActionItem>() {
-    override fun areItemsTheSame(
-        oldItem: DebugReportTimelineEventActionItem,
-        newItem: DebugReportTimelineEventActionItem,
-    ): Boolean = oldItem.id == newItem.id
+    override fun getItemCount(): Int = items.size
 
-    override fun areContentsTheSame(
-        oldItem: DebugReportTimelineEventActionItem,
-        newItem: DebugReportTimelineEventActionItem,
-    ): Boolean = oldItem == newItem
+    fun setItems(newItems: List<DebugReportTimelineEventActionItem>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
 }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/adapter/ItemTimelineEventViewHolder.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/adapter/ItemTimelineEventViewHolder.kt
@@ -37,6 +37,7 @@ class ItemTimelineEventViewHolder private constructor(
 
     init {
         viewBinding.actions.adapter = actionsAdapter
+        viewBinding.actions.itemAnimator = null
     }
 
     fun bind(
@@ -51,6 +52,6 @@ class ItemTimelineEventViewHolder private constructor(
             conditionsText.text = item.conditionsText
         }
 
-        actionsAdapter.submitList(item.actions)
+        actionsAdapter.setItems(item.actions)
     }
 }

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/filter/DebugReportTimelineFiltersViewModel.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/timeline/filter/DebugReportTimelineFiltersViewModel.kt
@@ -19,7 +19,7 @@ package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.tim
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import com.buzbuz.smartautoclicker.feature.smart.debugging.R
-import com.buzbuz.smartautoclicker.feature.smart.debugging.utils.formatDebugTimelineTimestamp
+import com.buzbuz.smartautoclicker.feature.smart.debugging.utils.formatDebugTimelineFilterTimestamp
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -67,7 +67,7 @@ class DebugReportTimelineFiltersViewModel @Inject constructor() : ViewModel() {
         _timeUiState.update { previous ->
             previous?.copy(
                 lowerValueMs = value,
-                lowerValueText = value.formatDebugTimelineTimestamp(),
+                lowerValueText = value.formatDebugTimelineFilterTimestamp(),
             )
         }
     }
@@ -80,7 +80,7 @@ class DebugReportTimelineFiltersViewModel @Inject constructor() : ViewModel() {
         _timeUiState.update { previous ->
             previous?.copy(
                 upperValueMs = value,
-                upperValueText = value.formatDebugTimelineTimestamp(),
+                upperValueText = value.formatDebugTimelineFilterTimestamp(),
             )
         }
     }
@@ -173,8 +173,8 @@ class DebugReportTimelineFiltersViewModel @Inject constructor() : ViewModel() {
             upperBoundMs = durationMs,
             lowerValueMs = lowerValue,
             upperValueMs = upperValue,
-            lowerValueText = lowerValue.formatDebugTimelineTimestamp(),
-            upperValueText = upperValue.formatDebugTimelineTimestamp(),
+            lowerValueText = lowerValue.formatDebugTimelineFilterTimestamp(),
+            upperValueText = upperValue.formatDebugTimelineFilterTimestamp(),
         )
     }
 

--- a/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/utils/Formatters.kt
+++ b/feature/smart-debugging/src/main/java/com/buzbuz/smartautoclicker/feature/smart/debugging/utils/Formatters.kt
@@ -54,3 +54,21 @@ internal fun Long.formatDebugTimelineTimestamp(): String {
 
     return value.trim()
 }
+
+/** Compact timestamp used for manually selecting a Timeline filter range. */
+internal fun Long.formatDebugTimelineFilterTimestamp(): String {
+    val duration = coerceAtLeast(0L).milliseconds
+
+    return when {
+        duration.inWholeMinutes < 1 -> {
+            val tenths = duration.inWholeMilliseconds / 100L
+            val wholeSeconds = tenths / 10L
+            val decimal = tenths % 10L
+            if (decimal == 0L) "${wholeSeconds}s" else "${wholeSeconds}.${decimal}s"
+        }
+        duration.inWholeHours < 1 ->
+            "${duration.inWholeMinutes}m ${duration.inWholeSeconds % 60}s"
+        else ->
+            "${duration.inWholeHours}h ${duration.inWholeMinutes % 60}m"
+    }
+}

--- a/feature/smart-debugging/src/main/res/drawable/ic_debug_conditions.xml
+++ b/feature/smart-debugging/src/main/res/drawable/ic_debug_conditions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M418,-340q24,24 62,23.5t56,-27.5l169,-253q9,-14 -2.5,-25.5T677,-625L424,-456q-27,18 -28.5,55t22.5,61ZM480,-800q36,0 71,6t68,19q16,6 34,22.5t10,31.5q-8,15 -36,20t-45,-1q-25,-9 -50.5,-13.5T480,-720q-133,0 -226.5,93.5T160,-400q0,42 11.5,83t32.5,77h552q23,-38 33.5,-79t10.5,-85q0,-26 -4.5,-51T782,-504q-6,-17 -2,-33t18,-27q13,-10 28.5,-6t21.5,18q15,35 23,71.5t9,74.5q1,57 -13,109t-41,99q-11,18 -30,28t-40,10H204q-21,0 -40,-10t-30,-28q-26,-45 -40,-95.5T80,-400q0,-83 31.5,-155.5t86,-127Q252,-737 325,-768.5T480,-800Z" />
+    </group>
+</vector>

--- a/feature/smart-debugging/src/main/res/drawable/ic_sort.xml
+++ b/feature/smart-debugging/src/main/res/drawable/ic_sort.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,18h6v-2H3v2zM3,11v2h12v-2H3zM3,6v2h18V6H3z" />
+</vector>

--- a/feature/smart-debugging/src/main/res/layout/content_condition_performance.xml
+++ b/feature/smart-debugging/src/main/res/layout/content_condition_performance.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/unavailable"
+        style="@style/AppTheme.TextAppearance.EmptyText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginHorizontal="@dimen/margin_horizontal_large"
+        android:gravity="center"
+        android:text="@string/title_condition_performance_unavailable"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <ProgressBar
+        android:id="@+id/loading"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="88dp"
+        android:clipToPadding="false"
+        android:visibility="gone"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/item_condition_performance" />
+
+    <com.buzbuz.smartautoclicker.core.ui.views.fastscroll.VerticalFastScrollerView
+        android:id="@+id/fast_scroller"
+        android:layout_width="32dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:contentDescription="@string/content_desc_condition_performance_fast_scroller"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/feature/smart-debugging/src/main/res/layout/content_debug_report_overview.xml
+++ b/feature/smart-debugging/src/main/res/layout/content_debug_report_overview.xml
@@ -108,6 +108,18 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
 
+            <com.google.android.material.divider.MaterialDivider
+                style="@style/AppTheme.Widget.Divider.Horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"/>
+
+            <!-- Event activity -->
+            <include
+                android:id="@+id/event_activity"
+                layout="@layout/include_event_activity_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/feature/smart-debugging/src/main/res/layout/content_debug_report_timeline.xml
+++ b/feature/smart-debugging/src/main/res/layout/content_debug_report_timeline.xml
@@ -34,9 +34,10 @@
         tools:visibility="visible">
 
         <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/empty_title"
             style="@style/AppTheme.TextAppearance.EmptyText"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/margin_horizontal_default"
             android:layout_gravity="center"
             android:gravity="center"
@@ -44,9 +45,10 @@
 
         <LinearLayout
             android:id="@+id/empty_secondary"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_vertical_extra_large"
+            android:gravity="center_horizontal"
             android:orientation="vertical"
             android:visibility="gone"
             tools:visibility="visible">
@@ -62,12 +64,22 @@
                 android:id="@+id/empty_secondary_text"
                 style="@style/AppTheme.TextAppearance.EmptyTextSecondary"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_vertical_small"
                 android:layout_marginHorizontal="@dimen/margin_horizontal_large"
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:text="@string/desc_event_occurrence_empty"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_clear_filters"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/margin_vertical_default"
+                android:text="@string/button_clear_timeline_filters"
+                android:visibility="gone"
+                tools:visibility="visible" />
 
         </LinearLayout>
 
@@ -85,7 +97,6 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list"
-        style="@style/AppTheme.RecyclerViewFastScroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
@@ -94,5 +105,14 @@
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listitem="@layout/item_dropdown"
         tools:visibility="gone"/>
+
+    <com.buzbuz.smartautoclicker.core.ui.views.fastscroll.VerticalFastScrollerView
+        android:id="@+id/fast_scroller"
+        android:layout_width="32dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:contentDescription="@string/content_desc_timeline_fast_scroller"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </FrameLayout>

--- a/feature/smart-debugging/src/main/res/layout/dialog_event_activity.xml
+++ b/feature/smart-debugging/src/main/res/layout/dialog_event_activity.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2026 Kevin Buzeau -->
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        style="@style/AppTheme.Dialog.BackgroundLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:minHeight="@dimen/bottom_sheet_min_height"
+        android:orientation="vertical">
+
+        <include
+            android:id="@+id/layout_top_bar"
+            layout="@layout/include_dialog_navigation_top_bar" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <ProgressBar
+                android:id="@+id/loading"
+                style="?android:attr/progressBarStyleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                tools:visibility="gone" />
+
+            <LinearLayout
+                android:id="@+id/empty"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/AppTheme.TextAppearance.EmptyText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_horizontal_default"
+                    android:gravity="center"
+                    android:text="@string/title_event_activity_empty" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/AppTheme.TextAppearance.EmptyTextSecondary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_horizontal_large"
+                    android:layout_marginTop="@dimen/margin_vertical_default"
+                    android:gravity="center"
+                    android:text="@string/desc_event_activity_empty" />
+
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingBottom="88dp"
+                android:visibility="gone"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_event_activity"
+                tools:visibility="visible" />
+
+            <com.buzbuz.smartautoclicker.core.ui.views.fastscroll.VerticalFastScrollerView
+                android:id="@+id/fast_scroller"
+                android:layout_width="32dp"
+                android:layout_height="match_parent"
+                android:layout_gravity="end"
+                android:contentDescription="@string/content_desc_event_activity_fast_scroller"
+                android:visibility="gone" />
+
+            <include
+                android:id="@+id/floating_action_buttons"
+                layout="@layout/include_floating_action_buttons"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|end" />
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/smart-debugging/src/main/res/layout/include_event_activity_summary.xml
+++ b/feature/smart-debugging/src/main/res/layout/include_event_activity_summary.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2026 Kevin Buzeau -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/field_min_height"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true">
+
+    <include
+        android:id="@+id/summary_data"
+        layout="@layout/include_field_data_display"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_horizontal_default"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/chevron"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/chevron"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_chevron_right"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/smart-debugging/src/main/res/layout/item_condition_performance.xml
+++ b/feature/smart-debugging/src/main/res/layout/item_condition_performance.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/AppTheme.Widget.Card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/margin_horizontal_default"
+    android:layout_marginVertical="@dimen/margin_horizontal_small">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/margin_horizontal_default"
+        android:paddingVertical="@dimen/margin_vertical_default">
+
+        <ImageView
+            android:id="@+id/condition_image"
+            android:layout_width="72dp"
+            android:layout_height="72dp"
+            android:background="?attr/colorSurfaceVariant"
+            android:contentDescription="@null"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_number_condition" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/condition_name_text"
+            style="@style/AppTheme.TextAppearance.ListItemTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal_default"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/percentage_text"
+            app:layout_constraintStart_toEndOf="@id/condition_image"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Drop Whatever" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/event_name_text"
+            style="@style/AppTheme.TextAppearance.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal_default"
+            app:layout_constraintEnd_toStartOf="@id/percentage_text"
+            app:layout_constraintStart_toEndOf="@id/condition_image"
+            app:layout_constraintTop_toBottomOf="@id/condition_name_text"
+            tools:text="Builder Attack" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/total_time_text"
+            style="@style/AppTheme.TextAppearance.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal_default"
+            android:layout_marginTop="@dimen/margin_vertical_small"
+            app:layout_constraintEnd_toStartOf="@id/percentage_text"
+            app:layout_constraintStart_toEndOf="@id/condition_image"
+            app:layout_constraintTop_toBottomOf="@id/event_name_text"
+            tools:text="Total time: 62.810 s" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/fulfilled_text"
+            style="@style/AppTheme.TextAppearance.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal_default"
+            app:layout_constraintEnd_toStartOf="@id/percentage_text"
+            app:layout_constraintStart_toEndOf="@id/condition_image"
+            app:layout_constraintTop_toBottomOf="@id/total_time_text"
+            tools:text="Fulfilled: 0 times out of 23,210 checks" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/average_text"
+            style="@style/AppTheme.TextAppearance.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal_default"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/percentage_text"
+            app:layout_constraintStart_toEndOf="@id/condition_image"
+            app:layout_constraintTop_toBottomOf="@id/fulfilled_text"
+            tools:text="Average: 2.706 ms per check" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/percentage_text"
+            android:layout_width="76dp"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="18.04%" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/feature/smart-debugging/src/main/res/layout/item_condition_performance_footer.xml
+++ b/feature/smart-debugging/src/main/res/layout/item_condition_performance_footer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textview.MaterialTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/AppTheme.TextAppearance.BodySmall"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/margin_horizontal_large"
+    android:paddingTop="@dimen/margin_vertical_default"
+    android:paddingBottom="@dimen/margin_vertical_extra_large"
+    android:gravity="center"
+    android:alpha="0.7"
+    android:text="@string/desc_condition_performance_footer" />

--- a/feature/smart-debugging/src/main/res/layout/item_event_activity.xml
+++ b/feature/smart-debugging/src/main/res/layout/item_event_activity.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2026 Kevin Buzeau -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/margin_horizontal_default"
+    android:minHeight="@dimen/field_min_height">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/event_name_text"
+        style="@style/AppTheme.TextAppearance.ListItemTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_horizontal_default"
+        android:maxLines="2"
+        app:layout_constraintBottom_toTopOf="@id/separator"
+        app:layout_constraintEnd_toStartOf="@id/occurrence_count_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Not Found Match" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/occurrence_count_text"
+        style="@style/AppTheme.TextAppearance.BodyLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        app:layout_constraintBottom_toBottomOf="@id/event_name_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/event_name_text"
+        tools:text="247×" />
+
+    <com.google.android.material.divider.MaterialDivider
+        android:id="@+id/separator"
+        style="@style/AppTheme.Widget.Divider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/smart-debugging/src/main/res/menu/menu_debug_report.xml
+++ b/feature/smart-debugging/src/main/res/menu/menu_debug_report.xml
@@ -22,6 +22,11 @@
         android:icon="@drawable/ic_debug_overview"
         android:title="@string/menu_item_debug_report_overview"/>
     <item
+        android:id="@+id/page_conditions"
+        android:enabled="true"
+        android:icon="@drawable/ic_debug_conditions"
+        android:title="@string/menu_item_debug_report_conditions"/>
+    <item
         android:id="@+id/page_timeline"
         android:enabled="true"
         android:icon="@drawable/ic_debug_timeline"

--- a/feature/smart-debugging/src/main/res/values/strings.xml
+++ b/feature/smart-debugging/src/main/res/values/strings.xml
@@ -33,6 +33,11 @@
     <!-- Debug Report Timeline Tab -->
     <string name="title_event_occurrence_empty">No events</string>
     <string name="desc_event_occurrence_empty">No events were executed during the last scenario session.</string>
+    <string name="title_event_occurrence_filtered_empty">No matching events</string>
+    <string name="desc_event_occurrence_filtered_empty">No Timeline events match the current filters.</string>
+    <string name="button_clear_timeline_filters">Clear filters</string>
+    <string name="content_desc_timeline_filters_active">%1$d Timeline filter categories active</string>
+    <string name="content_desc_timeline_fast_scroller">Timeline fast scroller</string>
     <string name="item_event_occurrence_frame_number">Frame #%1$d</string>
     <string name="item_event_occurrence_trigger">Trigger</string>
     <string name="item_event_occurrence_one_condition_fulfilled">Fulfilled: %1$s</string>

--- a/feature/smart-debugging/src/main/res/values/strings.xml
+++ b/feature/smart-debugging/src/main/res/values/strings.xml
@@ -29,6 +29,30 @@
     <string name="item_title_report_avg_image_processing_duration">Average processing duration</string>
     <string name="item_title_report_image_event_fulfilled">Screen Events fulfilled</string>
     <string name="item_title_report_trigger_event_fulfilled">Trigger Events fulfilled</string>
+    <string name="item_title_report_event_activity">Event activity</string>
+    <string name="item_desc_report_event_activity_empty">No events reached</string>
+    <plurals name="item_desc_report_event_activity_reached">
+        <item quantity="one">%1$d event reached · %2$d total occurrences</item>
+        <item quantity="other">%1$d events reached · %2$d total occurrences</item>
+    </plurals>
+    <string name="item_desc_report_event_activity_most_frequent">Most frequent: %1$s · %2$d×</string>
+
+    <!-- Debug Report Event Activity dialog -->
+    <string name="dialog_overlay_title_event_activity">Event activity</string>
+    <string name="item_event_activity_screen_events">Screen Events</string>
+    <string name="item_event_activity_trigger_events">Trigger Events</string>
+    <string name="item_event_activity_occurrence_count" translatable="false">%1$d×</string>
+    <string name="title_event_activity_empty">No events available</string>
+    <string name="desc_event_activity_empty">This scenario does not currently contain any events.</string>
+    <string name="content_desc_event_activity_sort">Sort Event activity</string>
+    <string name="content_desc_event_activity_fast_scroller">Event activity fast scroller</string>
+    <string name="dialog_overlay_title_event_activity_sort">Sort Event activity</string>
+    <string name="event_activity_sort_scenario_order">Scenario order</string>
+    <string name="event_activity_sort_scenario_order_desc">Use the order shown in the Scenario editor</string>
+    <string name="event_activity_sort_most_frequent">Most frequent</string>
+    <string name="event_activity_sort_most_frequent_desc">Show events with the most occurrences first</string>
+    <string name="event_activity_sort_first_execution">First execution</string>
+    <string name="event_activity_sort_first_execution_desc">Use the order in which events were first reached</string>
 
     <!-- Debug Report Timeline Tab -->
     <string name="title_event_occurrence_empty">No events</string>

--- a/feature/smart-debugging/src/main/res/values/strings.xml
+++ b/feature/smart-debugging/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
 
     <string name="dialog_overlay_title_debug_report">Debug report</string>
     <string name="menu_item_debug_report_overview">Overview</string>
+    <string name="menu_item_debug_report_conditions">Conditions</string>
     <string name="menu_item_debug_report_timeline">Timeline</string>
 
     <!-- Debug Report Overview Tab-->
@@ -53,6 +54,32 @@
     <string name="event_activity_sort_most_frequent_desc">Show events with the most occurrences first</string>
     <string name="event_activity_sort_first_execution">First execution</string>
     <string name="event_activity_sort_first_execution_desc">Use the order in which events were first reached</string>
+
+    <!-- Debug Report Conditions Tab -->
+    <string name="title_condition_performance_unavailable">Condition performance is not available for this report.</string>
+    <string name="content_desc_condition_performance_fast_scroller">Condition performance fast scroller</string>
+    <string name="item_condition_performance_total_time">Total time: %1$s s</string>
+    <string name="item_condition_performance_fulfilled">Fulfilled: %1$s %2$s out of %3$s %4$s</string>
+    <plurals name="item_condition_performance_time">
+        <item quantity="one">time</item>
+        <item quantity="other">times</item>
+    </plurals>
+    <plurals name="item_condition_performance_check">
+        <item quantity="one">check</item>
+        <item quantity="other">checks</item>
+    </plurals>
+    <string name="item_condition_performance_average">Average: %1$s ms per check</string>
+    <string name="item_condition_performance_average_unavailable">Average: N/A</string>
+    <string name="desc_condition_performance_footer">Percentages show each condition’s share of the total time spent checking conditions in this report. They do not represent total scenario time or battery usage.</string>
+    <string name="dialog_overlay_title_condition_performance_sort">Sort Conditions</string>
+    <string name="condition_performance_sort_total_time">Total time</string>
+    <string name="condition_performance_sort_total_time_desc">Show conditions with the greatest cumulative processing time first</string>
+    <string name="condition_performance_sort_average">Average per check</string>
+    <string name="condition_performance_sort_average_desc">Show conditions with the greatest average processing time first</string>
+    <string name="condition_performance_sort_checks">Checks</string>
+    <string name="condition_performance_sort_checks_desc">Show the most frequently checked conditions first</string>
+    <string name="condition_performance_sort_scenario_order">Scenario order</string>
+    <string name="condition_performance_sort_scenario_order_desc">Use the condition order configured in the scenario</string>
 
     <!-- Debug Report Timeline Tab -->
     <string name="title_event_occurrence_empty">No events</string>

--- a/feature/smart-debugging/src/test/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityReportTests.kt
+++ b/feature/smart-debugging/src/test/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/activity/EventActivityReportTests.kt
@@ -1,0 +1,112 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.activity
+
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.DebugReportEventOccurrence
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+
+class EventActivityReportTests {
+
+    @Test
+    fun `duplicate names remain distinct and counts are aggregated`() {
+        val report = buildEventActivityReport(
+            screenEvents = listOf(screenSource(1, "Find", 0), screenSource(2, "Find", 1)),
+            triggerEvents = emptyList(),
+            occurrences = listOf(screenOccurrence(1), screenOccurrence(2), screenOccurrence(1)),
+        )
+
+        assertEquals(2, report.reachedEventCount)
+        assertEquals(3, report.totalOccurrenceCount)
+        assertEquals(listOf(2, 1), report.screenEvents.map { it.occurrenceCount })
+        assertEquals(1L, report.mostFrequentEvent?.key?.eventId)
+    }
+
+    @Test
+    fun `screen and trigger events with the same id never merge`() {
+        val report = buildEventActivityReport(
+            screenEvents = listOf(screenSource(7, "Screen", 0)),
+            triggerEvents = listOf(triggerSource(7, "Trigger", 0)),
+            occurrences = listOf(screenOccurrence(7), triggerOccurrence(7), triggerOccurrence(7)),
+        )
+
+        assertEquals(1, report.screenEvents.single().occurrenceCount)
+        assertEquals(2, report.triggerEvents.single().occurrenceCount)
+        assertEquals(EventActivityType.TRIGGER, report.mostFrequentEvent?.key?.type)
+    }
+
+    @Test
+    fun `most frequent ties use scenario order deterministically`() {
+        val report = buildEventActivityReport(
+            screenEvents = listOf(screenSource(20, "Second", 1), screenSource(10, "First", 0)),
+            triggerEvents = emptyList(),
+            occurrences = listOf(screenOccurrence(20), screenOccurrence(10)),
+            sort = EventActivitySort.MOST_FREQUENT,
+        )
+
+        assertEquals(listOf(10L, 20L), report.screenEvents.map { it.key.eventId })
+        assertEquals(10L, report.mostFrequentEvent?.key?.eventId)
+    }
+
+    @Test
+    fun `first execution puts unreached events last in scenario order`() {
+        val report = buildEventActivityReport(
+            screenEvents = listOf(
+                screenSource(1, "Unreached first", 0),
+                screenSource(2, "Reached second", 1),
+                screenSource(3, "Reached first", 2),
+                screenSource(4, "Unreached second", 3),
+            ),
+            triggerEvents = emptyList(),
+            occurrences = listOf(screenOccurrence(3), screenOccurrence(2)),
+            sort = EventActivitySort.FIRST_EXECUTION,
+        )
+
+        assertEquals(listOf(3L, 2L, 1L, 4L), report.screenEvents.map { it.key.eventId })
+    }
+
+    @Test
+    fun `missing event references are ignored safely`() {
+        val report = buildEventActivityReport(
+            screenEvents = listOf(screenSource(1, "Known", 0)),
+            triggerEvents = emptyList(),
+            occurrences = listOf(screenOccurrence(99)),
+        )
+
+        assertEquals(0, report.reachedEventCount)
+        assertEquals(0, report.totalOccurrenceCount)
+        assertEquals(0, report.screenEvents.single().occurrenceCount)
+        assertNull(report.mostFrequentEvent)
+    }
+
+    private fun screenSource(id: Long, name: String, order: Int) = EventActivitySource(
+        key = EventActivityKey(EventActivityType.SCREEN, id),
+        name = name,
+        scenarioOrder = order,
+    )
+
+    private fun triggerSource(id: Long, name: String, order: Int) = EventActivitySource(
+        key = EventActivityKey(EventActivityType.TRIGGER, id),
+        name = name,
+        scenarioOrder = order,
+    )
+
+    private fun screenOccurrence(id: Long) = DebugReportEventOccurrence.ScreenEvent(
+        eventId = id,
+        relativeTimestampMs = 0,
+        conditionsResults = emptyList(),
+        counterChanges = emptyList(),
+        eventStateChanges = emptyList(),
+        frameNumber = 0,
+    )
+
+    private fun triggerOccurrence(id: Long) = DebugReportEventOccurrence.TriggerEvent(
+        eventId = id,
+        relativeTimestampMs = 0,
+        conditionsResults = emptyList(),
+        counterChanges = emptyList(),
+        eventStateChanges = emptyList(),
+    )
+}

--- a/feature/smart-debugging/src/test/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceReportTests.kt
+++ b/feature/smart-debugging/src/test/java/com/buzbuz/smartautoclicker/feature/smart/debugging/ui/dialog/report/conditions/ConditionPerformanceReportTests.kt
@@ -1,0 +1,155 @@
+/* Copyright (C) 2026 Kevin Buzeau */
+package com.buzbuz.smartautoclicker.feature.smart.debugging.ui.dialog.report.conditions
+
+import com.buzbuz.smartautoclicker.core.base.identifier.Identifier
+import com.buzbuz.smartautoclicker.core.domain.model.condition.TriggerCondition
+import com.buzbuz.smartautoclicker.core.smart.debugging.domain.model.report.ConditionProfile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ConditionPerformanceReportTests {
+
+    @Test
+    fun `profiles aggregate and percentages use the complete report denominator`() {
+        val report = buildConditionPerformanceReport(
+            conditions = listOf(source(1, "Shown", 0)),
+            profiles = listOf(profile(1, checks = 2, fulfilled = 1, totalNs = 20), profile(99, totalNs = 80)),
+        )
+
+        assertEquals(2L, report.single().checkCount)
+        assertEquals(1L, report.single().fulfilledCount)
+        assertEquals(100L, report.single().totalMeasuredDurationNs)
+        assertEquals("20.00%", formatPercentage(20, 100))
+    }
+
+    @Test
+    fun `all-zero durations do not divide by zero and unchecked average is unavailable`() {
+        val report = buildConditionPerformanceReport(
+            conditions = listOf(source(1, "Skipped", 0), source(2, "Also skipped", 1)),
+            profiles = emptyList(),
+        )
+
+        assertEquals(listOf(0L, 0L), report.map { it.checkCount })
+        assertNull(formatAverageDuration(report.first().totalDurationNs, report.first().checkCount))
+        assertEquals("0%", formatPercentage(0, 0))
+    }
+
+    @Test
+    fun `tiny non-zero measurements remain visible`() {
+        assertEquals("0.000000001", formatTotalDuration(1))
+        assertEquals("0.000001", formatAverageDuration(totalDurationNs = 1, checkCount = 1))
+        assertEquals("<0.01%", formatPercentage(1, 20_000))
+    }
+
+    @Test
+    fun `durations use four meaningful digits and remove trailing decimal zeroes`() {
+        assertEquals("1.234", formatTotalDuration(1_234_000_000))
+        assertEquals("0.002945", formatTotalDuration(2_945_000))
+        assertEquals("345.2", formatTotalDuration(345_234_000_000))
+        assertEquals("3207", formatTotalDuration(3_207_000_000_000))
+        assertEquals("90253", formatTotalDuration(90_253_000_000_000))
+        assertEquals("0.5321", formatTotalDuration(532_100_000))
+        assertEquals("424", formatTotalDuration(424_000_000_000))
+        assertEquals("0.004", formatTotalDuration(4_000_000))
+        assertEquals("0.9216", formatTotalDuration(921_591_721))
+    }
+
+    @Test
+    fun `average milliseconds use the same four meaningful digit rule`() {
+        assertEquals("1.234", formatAverageDuration(totalDurationNs = 1_234_000, checkCount = 1))
+        assertEquals("0.002945", formatAverageDuration(totalDurationNs = 2_945, checkCount = 1))
+        assertEquals("345.2", formatAverageDuration(totalDurationNs = 345_234_000, checkCount = 1))
+        assertEquals("424", formatAverageDuration(totalDurationNs = 424_000_000, checkCount = 1))
+    }
+
+    @Test
+    fun `duplicate condition names remain distinct`() {
+        val report = buildConditionPerformanceReport(
+            conditions = listOf(source(1, "Same", 0), source(2, "Same", 1)),
+            profiles = listOf(profile(1, totalNs = 10), profile(2, totalNs = 20)),
+        )
+
+        assertEquals(listOf(2L, 1L), report.map { it.condition.id.databaseId })
+    }
+
+    @Test
+    fun `total average and check sorting are descending with stable ties`() {
+        val sources = listOf(source(1, "First", 0), source(2, "Second", 1), source(3, "Third", 2))
+        val profiles = listOf(
+            profile(1, checks = 2, totalNs = 20),
+            profile(2, checks = 4, totalNs = 20),
+            profile(3, checks = 1, totalNs = 5),
+        )
+
+        assertEquals(listOf(1L, 2L, 3L), ids(buildConditionPerformanceReport(sources, profiles, ConditionPerformanceSort.TOTAL_TIME)))
+        assertEquals(listOf(1L, 2L, 3L), ids(buildConditionPerformanceReport(sources, profiles, ConditionPerformanceSort.AVERAGE_PER_CHECK)))
+        assertEquals(listOf(2L, 1L, 3L), ids(buildConditionPerformanceReport(sources, profiles, ConditionPerformanceSort.CHECKS)))
+    }
+
+    @Test
+    fun `scenario sorting restores configured order`() {
+        val report = buildConditionPerformanceReport(
+            conditions = listOf(source(3, "Third", 2), source(1, "First", 0), source(2, "Second", 1)),
+            profiles = listOf(profile(3, totalNs = 30), profile(1, totalNs = 10), profile(2, totalNs = 20)),
+            sort = ConditionPerformanceSort.SCENARIO_ORDER,
+        )
+
+        assertEquals(listOf(1L, 2L, 3L), ids(report))
+    }
+
+    @Test
+    fun `short-circuited conditions stay present with zero checks and sort last`() {
+        val report = buildConditionPerformanceReport(
+            conditions = listOf(source(1, "Reached", 0), source(2, "Short-circuited", 1)),
+            profiles = listOf(profile(1, checks = 5, totalNs = 50), profile(2, checks = 0, totalNs = 0)),
+            sort = ConditionPerformanceSort.AVERAGE_PER_CHECK,
+        )
+
+        assertEquals(listOf(1L, 2L), ids(report))
+        assertEquals(0L, report.last().checkCount)
+    }
+
+    @Test
+    fun `missing profiling record remains unavailable while present empty record is valid`() {
+        val conditions = listOf(source(1, "Condition", 0))
+
+        assertNull(buildConditionPerformanceReportOrNull(conditions, null))
+        assertEquals(1, buildConditionPerformanceReportOrNull(conditions, emptyList())?.size)
+    }
+
+    @Test
+    fun `full and near-full percentages are not confused`() {
+        assertEquals("100%", formatPercentage(100, 100))
+        assertEquals("99.99%", formatPercentage(999_999, 1_000_000))
+    }
+
+    private fun source(id: Long, name: String, order: Int) = ConditionPerformanceSource(
+        condition = TriggerCondition.OnTimerReached(
+            id = Identifier(id),
+            eventId = Identifier(100 + id),
+            name = name,
+            durationMs = 1_000,
+            restartWhenReached = false,
+        ),
+        eventName = "Event $id",
+        scenarioOrder = order,
+    )
+
+    private fun profile(
+        id: Long,
+        checks: Long = 1,
+        fulfilled: Long = 0,
+        totalNs: Long,
+    ) = ConditionProfile(
+        conditionId = id,
+        checkCount = checks,
+        fulfilledCount = fulfilled,
+        totalDurationNs = totalNs,
+        minDurationNs = if (checks == 0L) 0 else totalNs / checks,
+        maxDurationNs = if (checks == 0L) 0 else totalNs,
+    )
+
+    private fun ids(report: List<ConditionPerformanceEntry>): List<Long> =
+        report.map { it.condition.id.databaseId }
+}


### PR DESCRIPTION
## Status: design checkpoint, not merge-ready

This draft PR intentionally stops after the low-level measurement and Debug Report storage foundation. It is opened now to give the maintainer an opportunity to review the detection-path boundary, overhead trade-offs, report schema, and likely UI direction before the broader Debug Report work is built on top.

The later UI and product work is essential before this can become mergeable. If this foundation is accepted, I intend to continue with the wider Debug Report overhaul described in [discussion #958](https://github.com/Nain57/Smart-AutoClicker/discussions/958), not ship condition timing as an isolated screen. The original feature context is in [discussion #1064](https://github.com/Nain57/Smart-AutoClicker/discussions/1064).

## What this foundation does

- Times every condition that is actually reached by `ConditionsVerifier`.
- Aggregates check count, fulfilled count, total duration, minimum duration, and maximum duration per condition ID.
- Uses fixed-size primitive arrays allocated once at report start.
- Performs no clock read or aggregate update when Debug Report generation is disabled.
- Writes one aggregate protobuf message through the existing serialized Debug Report writer when the session ends.
- Adds active `ScenarioProcessor.process` time and actual Execution Limiter suspension time to the existing report overview.
- Adds a repository read path for the condition aggregates; no UI consumes it yet.
- Preserves compatibility with reports that predate the new optional protobuf fields.

The measurement contract is documented in [`docs/debug-report-performance-timing.md`](https://github.com/vibhor1102/Smart-AutoClicker/blob/feature/debug-report-condition-performance/docs/debug-report-performance-timing.md).

## Measurement boundary

The timer starts immediately before `verifyCondition(condition)` and stops immediately after it returns. This includes the preparation and detector work attributable to that reached condition, including image bitmap retrieval where applicable.

AND/OR short-circuiting is preserved: skipped conditions are not counted as checks. Configured but unreached conditions remain in the aggregate with zero values, which makes the absence of checks explicit.

Nanoseconds are used as the integer storage unit and monotonic-clock interface; this is not a claim of nanosecond measurement accuracy. Presentation would normally select microseconds or milliseconds.

## Prototype and real-device validation

Before converting the prototype into this permanent architecture, I tested all four combinations independently:

- **A — baseline:** existing Debug Report off, condition timing off.
- **B — existing report only:** existing Debug Report on, condition timing off.
- **C — combined intended use:** existing Debug Report on, condition timing on.
- **D — timing isolated:** existing Debug Report off, condition timing on.

| Mode | Existing report | Condition timing | Runs | Median elapsed | Median CPU ticks | Median CPU ticks/s |
|---|---:|---:|---:|---:|---:|---:|
| A | Off | Off | 5 | 54.461 s | 5,049 | 92.68 |
| B | On | Off | 5 | 53.848 s | 6,719 | 122.93 |
| C | On | On | 5 | 53.470 s | 6,703 | 125.63 |
| D | Off | On | 5 | 53.105 s | 4,893 | 92.22 |

The experiment used 20 valid real-world runs on an Android 14 device. Each run executed the same six-loop game automation with a 10/s Execution Limiter. Modes used the balanced rotation `C A B D / A D C B / C B A D / B D A C / D B A C` to distribute warm-up and heating bias.

The two incremental comparisons were:

- **B → C:** median elapsed -0.378 s, median raw CPU ticks -16, normalized CPU ticks approximately +2.2%.
- **A → D:** median elapsed -1.356 s, median raw CPU ticks -156, normalized CPU ticks approximately -0.5%.

The negative values are not interpreted as improvements. Their mixed directions and size relative to the natural run variance indicate that the added measurement cost did not stand out in this workload. The existing Debug Report path did produce a clearly visible CPU-tick increase, so the experiment was capable of exposing an effect larger than the noise.

All runs completed successfully. Device temperature rose from 41 °C to 45 °C and then remained stable; Android thermal status stayed at 0. The ten timing-enabled runs recorded 604,013 condition checks and 348.080 seconds of accumulated condition-processing time without malformed or missing profiles.

The data also demonstrated why the feature is useful: four conditions in one event consumed 65.94% of measured condition time, while two individually cheap conditions were important because each was reached more than 80,000 times.

The complete methodology, ranges, interpretation, and limitations are documented in [`docs/debug-report-performance-benchmark.md`](https://github.com/vibhor1102/Smart-AutoClicker/blob/feature/debug-report-condition-performance/docs/debug-report-performance-benchmark.md).

## Tests and build validation

Focused regression tests cover the failure modes most likely to produce plausible but incorrect reports:

- AND/OR short-circuit reach counting;
- no timing interaction on the disabled path;
- aggregate arithmetic and session reset;
- separation of active processing from limiter waiting;
- exclusion of the unlimited-mode safety delay from limiter time;
- partial limiter waits interrupted by cancellation;
- protobuf round trips; and
- old overview messages with absent timing fields.

The upstream-based debug APK compiled and verified successfully, and the full unit-test suite passed in [hosted run 32485154791](https://github.com/vibhor1102/Smart-AutoClicker/actions/runs/32485154791). That run used the same permanent code; this PR branch additionally squashes the history and adds the benchmark documentation while deliberately omitting fork-only workflows.

## UI direction for later phases

No UI is proposed in code here. My current preference is a third Debug Report tab dedicated to condition performance, because the data needs cumulative-time ranking, check counts, average cost, unreached conditions, sorting, and explanatory context.

Discussion #958 originally preferred keeping only Overview and Timeline for the smaller Event activity feature. A compact Overview entry opening a condition-performance screen remains a credible alternative. The scope now appears large enough that a dedicated tab may be clearer, but this is deliberately open for maintainer input.

The eventual implementation is expected to address #958 as a cohesive Debug Report overhaul: timeline readability and navigation, terminology, event activity, adaptive time formatting, and condition performance should be designed together rather than appended piecemeal.

## Feedback requested

In particular, feedback would be useful on:

1. Is `verifyCondition` the right attribution boundary, or should any bitmap/preparation work sit outside it?
2. Is one aggregate message at session end consistent with the intended Debug Report format?
3. Should active processing and Execution Limiter waiting live in the overview as proposed?
4. Is a dedicated condition-performance tab preferable to an Overview entry opening a separate screen?
5. Are there other low-level measurements worth collecting now, before a UI contract is fixed?

## FAQ

### Why use elapsed time rather than CPU time?

The user can act on end-to-end condition latency: both detector work and condition-specific preparation delay the next evaluation. Per-thread CPU time would miss native or other-thread work and would be harder to interpret. The report does not claim that elapsed time maps directly to battery consumption.

### Why time every check instead of sampling?

The timer and fixed-array update were not detectable above real-world variance, while full coverage gives exact reach counts and does not risk missing rare expensive conditions. Sampling can be reconsidered if the detection architecture changes materially.

### Why aggregate instead of storing individual samples?

Individual samples would make memory and report size grow with session length and would introduce hot-path allocation or buffering pressure. The aggregate uses a fixed amount of memory per configured condition and performs no per-check I/O.

### Why store nanoseconds if the detector is not nanosecond-accurate?

Nanoseconds avoid early rounding when many short checks are accumulated and match Android's monotonic clock API. They are a storage unit, not a display promise; the UI should use readable adaptive units.

### Why keep minimum and maximum but not percentiles?

Min/max cost only two primitive fields and can expose extreme behavior. Reliable percentiles require retaining samples or updating a histogram on every check. That additional complexity and overhead is deferred until there is evidence that the UI needs it.

### Why identify entries by condition database ID rather than duplicate names and types?

The report already belongs to a specific scenario. IDs allow readers to join timing to the scenario's condition metadata without duplicating mutable names, priorities, operators, and event relationships in every aggregate entry.

### Why is there no separate profiling toggle?

This is a Debug Report sub-feature, not an independent profiler. Enabling the report enables its complete data collection. Keeping separate state would allow internally inconsistent reports and add a user-facing setting for an overhead that was not detectable in validation.

### Why add a synchronous timing listener instead of reusing the existing asynchronous callbacks?

The duration must be captured at the exact condition boundary, and aggregate ordering must match the processing path. The listener only updates primitive arrays/integers; file writing and domain-object creation still happen once, after processing stops, through the existing report writer.

### Why record active loop time and limiter waiting separately?

`session duration - active duration` is not limiter time: it also includes actions, unavailable-frame delays, and other waits. Measuring at the limiter's own suspension site makes that value honest and actionable. Unlimited-mode safety waits are explicitly excluded.

### Why open a draft before the UI exists?

The measurement boundary and hot-path architecture are difficult to change after UI and analytics depend on them. This draft is a review checkpoint for those foundations, especially because the later work will be a broader Debug Report redesign rather than a small isolated addition.

## Out of scope for this draft

- User-facing screens or formatting
- Automated optimization recommendations
- Percentiles or histograms
- Battery/CPU attribution
- The complete set of changes proposed in #958

This PR should remain draft and should not be merged in its current form.
