### PR TITLE
[#1069] Change version codes for FDroid abi split

### DIFF
--- a/smartautoclicker/build.gradle.kts
+++ b/smartautoclicker/build.gradle.kts
@@ -124,7 +124,7 @@ if (project.isBuildForVariant(KlickrFlavour.F_DROID)) {
                 else          -> 0  // universal
             }
             val baseVersionCode = output.versionCode.get()
-            output.versionCode.set(abiVersionCode * 10_000 + baseVersionCode)
+            output.versionCode.set(baseVersionCode * 10_000 + abiVersionCode)
         }
     }
 }


### PR DESCRIPTION
Changes version codes management:

**Currently:**
* armeabi-v7a	1 * 10_000 + 95 = 10,095
* arm64-v8a	2 * 10_000 + 95 = 20,095
* x86	        3 * 10_000 + 95 = 30,095
* x86_64	        4 * 10_000 + 95 = 40,095

**Requested:**
* armeabi-v7a	95 * 10_000 + 1 = 950,001
* arm64-v8a	95 * 10_000 + 2 = 950,002
* x86	        95 * 10_000 + 3 = 950,003
* x86_64	        95 * 10_000 + 4 = 950,004